### PR TITLE
Fix VLAN Status

### DIFF
--- a/nautobot_ssot_infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/models/nautobot.py
@@ -99,14 +99,15 @@ class NautobotVlan(Vlan):
         _vlan.validated_save()
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
 
+    @staticmethod
     def get_vlan_status(status: str) -> str:
         """Method to return VLAN Status from mapping."""
-        STATUSES = {
+        statuses = {
             "ASSIGNED": "Active",
             "UNASSIGNED": "Deprecated",
             "RESERVED": "Reserved",
         }
-        return STATUSES[status]
+        return statuses[status]
 
     def update(self, attrs):
         """Update VLAN object in Nautobot."""


### PR DESCRIPTION
This PR fixes the VLAN Status creation to use mapping for assigned, reserved, and unassigned status. Also adds description.