### PR TITLE
Add support for Network Containers in RFC1918.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ PLUGINS_CONFIG = {
         "NAUTOBOT_INFOBLOX_PASSWORD": os.getenv("NAUTOBOT_INFOBLOX_PASSWORD", ""),
         "NAUTOBOT_INFOBLOX_VERIFY_SSL": os.getenv("NAUTOBOT_INFOBLOX_VERIFY_SSL", "true"),
         "NAUTOBOT_INFOBLOX_WAPI_VERSION": os.getenv("NAUTOBOT_INFOBLOX_WAPI_VERSION", "v2.12"),
+        "enable_sync_to_infoblox": False,
+        "enable_rfc1918_network_containers": False,
     }
 }
 ```

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -306,6 +306,7 @@ PLUGINS_CONFIG = {
         "NAUTOBOT_INFOBLOX_VERIFY_SSL": os.getenv("NAUTOBOT_INFOBLOX_VERIFY_SSL", "true"),
         "NAUTOBOT_INFOBLOX_WAPI_VERSION": os.getenv("NAUTOBOT_INFOBLOX_WAPI_VERSION", "v2.12"),
         "enable_sync_to_infoblox": False,
+        "enable_rfc1918_network_containers": True,
     },
     "nautobot_ssot": {
         "hide_example_jobs": True,

--- a/nautobot_ssot_infoblox/__init__.py
+++ b/nautobot_ssot_infoblox/__init__.py
@@ -28,6 +28,7 @@ class NautobotSSoTInfobloxConfig(PluginConfig):
     max_version = "1.9999"
     default_settings = {
         "enable_sync_to_infoblox": False,
+        "enable_rfc1918_network_containers": False,
     }
     caching_config = {}
 

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -1,8 +1,14 @@
 """Nautobot Adapter for Infoblox integration with SSoT plugin."""
 import re
 from diffsync import DiffSync
-from nautobot.ipam.models import IPAddress, Prefix, VLAN, VLANGroup
-from nautobot_ssot_infoblox.diffsync.models import NautobotNetwork, NautobotIPAddress, NautobotVlanGroup, NautobotVlan
+from nautobot.ipam.models import Aggregate, IPAddress, Prefix, VLAN, VLANGroup
+from nautobot_ssot_infoblox.diffsync.models import (
+    NautobotAggregate,
+    NautobotNetwork,
+    NautobotIPAddress,
+    NautobotVlanGroup,
+    NautobotVlan,
+)
 from nautobot_ssot_infoblox.utils import nautobot_vlan_status
 
 
@@ -77,3 +83,31 @@ class NautobotAdapter(DiffSync):
         self.load_ipaddresses()
         self.load_vlangroups()
         self.load_vlans()
+
+
+class NautobotAggregateAdapter(DiffSync):
+    """DiffSync adapter using ORM to communicate to Nautobot Aggregrates."""
+
+    aggregate = NautobotAggregate
+
+    top_level = ["aggregate"]
+
+    def __init__(self, *args, job=None, sync=None, **kwargs):
+        """Initialize Nautobot.
+
+        Args:
+            job (object, optional): Nautobot job. Defaults to None.
+            sync (object, optional): Nautobot DiffSync. Defaults to None.
+        """
+        super().__init__(*args, **kwargs)
+        self.job = job
+        self.sync = sync
+
+    def load(self):
+        """Method to load aggregate models from Nautobot."""
+        for aggregate in Aggregate.objects.all():
+            _aggregate = self.aggregate(
+                network=str(aggregate.prefix),
+                description=aggregate.description,
+            )
+            self.add(_aggregate)

--- a/nautobot_ssot_infoblox/diffsync/models/__init__.py
+++ b/nautobot_ssot_infoblox/diffsync/models/__init__.py
@@ -1,13 +1,15 @@
 """Initialize models for Nautobot and Infoblox."""
-from .nautobot import NautobotNetwork, NautobotIPAddress, NautobotVlanGroup, NautobotVlan
-from .infoblox import InfobloxNetwork, InfobloxIPAddress, InfobloxVLANView, InfobloxVLAN
+from .nautobot import NautobotAggregate, NautobotNetwork, NautobotIPAddress, NautobotVlanGroup, NautobotVlan
+from .infoblox import InfobloxAggregate, InfobloxNetwork, InfobloxIPAddress, InfobloxVLANView, InfobloxVLAN
 
 
 __all__ = [
+    "NautobotAggregate",
     "NautobotNetwork",
     "NautobotIPAddress",
     "NautobotVlanGroup",
     "NautobotVlan",
+    "InfobloxAggregate",
     "InfobloxNetwork",
     "InfobloxIPAddress",
     "InfobloxVLANView",

--- a/nautobot_ssot_infoblox/diffsync/models/base.py
+++ b/nautobot_ssot_infoblox/diffsync/models/base.py
@@ -51,3 +51,14 @@ class IPAddress(DiffSyncModel):
     prefix: str
     status: str
     description: Optional[str]
+
+
+class Aggregate(DiffSyncModel):
+    """Aggregate model for DiffSync."""
+
+    _modelname = "aggregate"
+    _identifiers = ("network",)
+    _attributes = ("description",)
+
+    network: str
+    description: Optional[str]

--- a/nautobot_ssot_infoblox/diffsync/models/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/models/infoblox.py
@@ -1,5 +1,5 @@
 """Infoblox Models for Infoblox integration with SSoT plugin."""
-from nautobot_ssot_infoblox.diffsync.models.base import Network, IPAddress, Vlan, VlanView
+from nautobot_ssot_infoblox.diffsync.models.base import Aggregate, Network, IPAddress, Vlan, VlanView
 
 
 class InfobloxNetwork(Network):
@@ -59,3 +59,27 @@ class InfobloxIPAddress(IPAddress):
             json = {"comment": attrs["description"]}
             self.diffsync.conn.update_ipaddress(address=self.get_identifiers()["address"], data=json)
         return super().update(attrs)
+
+
+class InfobloxAggregate(Aggregate):
+    """Infoblox implementation of the Aggregate Model."""
+
+    @classmethod
+    def create(cls, diffsync, ids, attrs):
+        """Create Network Container object in Infoblox."""
+        diffsync.conn.create_network_container(
+            prefix=ids["network"], comment=attrs["description"] if attrs.get("description") else ""
+        )
+        return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
+
+    def update(self, attrs):
+        """Update Network Container object in Infoblox."""
+        self.diffsync.conn.update_network_container(
+            prefix=self.get_identifiers()["network"], comment=attrs["description"] if attrs.get("description") else ""
+        )
+        return super().update(attrs)
+
+    def delete(self):
+        """Delete Network Container object in Infoblox."""
+        self.diffsync.conn.delete_network_container(self.get_identifiers()["network"])
+        return super().delete()

--- a/nautobot_ssot_infoblox/jobs.py
+++ b/nautobot_ssot_infoblox/jobs.py
@@ -105,7 +105,52 @@ class InfobloxDataTarget(DataTarget, Job):
             self.log_success(message="Sync complete.")
 
 
+class InfobloxNetworkContainerSource(DataSource, Job):
+    """Infoblox SSoT Network Container Source."""
+
+    debug = BooleanVar(description="Enable for verbose debug logging.")
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        """Information about the Job."""
+
+        name = "Infoblox Network Containers"
+        data_source = "InfobloxNetworkContainers"
+        data_source_icon = static("nautobot_ssot_infoblox/infoblox_logo.png")
+        description = "Sync Network Container (Aggregate) infomation from Infoblox to Nautobot"
+
+    @classmethod
+    def data_mappings(cls):
+        """Shows mapping of models between Infoblox and Nautobot."""
+        return (DataMapping("networkcontainer", None, "Aggregate", reverse("ipam:aggregate_list")),)
+
+    def sync_data(self):
+        """Method to handle synchronization of data to Nautobot."""
+        self.log_info(message="Connecting to Infoblox")
+        infoblox_adapter = infoblox.InfobloxAggregateAdapter(job=self, sync=self.sync)
+        self.log_info(message="Loading data from Infoblox...")
+        infoblox_adapter.load()
+        self.log_info(message="Connecting to Nautobot...")
+        nb_adapter = nautobot.NautobotAggregateAdapter(job=self, sync=self.sync)
+        self.log_info(message="Loading data from Nautobot...")
+        nb_adapter.load()
+        self.log_info(message="Performing diff of data between Infoblox and Nautobot.")
+        diff = nb_adapter.diff_from(infoblox_adapter, flags=DiffSyncFlags.CONTINUE_ON_FAILURE)
+        self.sync.diff = diff.dict()
+        self.sync.save()
+        self.log_info(message=diff.summary())
+        if not self.kwargs["dry_run"]:
+            self.log_info(message="Performing data synchronization from Infoblox to Nautobot.")
+            try:
+                nb_adapter.sync_from(infoblox_adapter, flags=DiffSyncFlags.CONTINUE_ON_FAILURE)
+            except ObjectNotCreated as err:
+                self.log_debug(f"Unable to create object. {err}")
+            self.log_success(message="Sync complete.")
+
+
 jobs = [InfobloxDataSource]
 
 if PLUGIN_CFG["enable_sync_to_infoblox"]:
     jobs.append(InfobloxDataTarget)
+
+if PLUGIN_CFG["enable_rfc1918_network_containers"]:
+    jobs.append(InfobloxNetworkContainerSource)


### PR DESCRIPTION
Since Aggregates in Nautobot require an RIR, and RIR's
in Infoblox are out of scope, only support Network Containers
that fall within the RFC1918, since we can auto-assign
to the RFC1918 RIR. Also corrects bugs in some of the
api calls.