### PR TITLE
feat: Add Extensibility Attributes (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ Below are the data mappings between objects within Infoblox and the correspondin
 | VLAN              | VLAN           |
 | VLAN view         | VLAN Group     |
 | Network container | Aggregate      |
+| Extensibility Attrs | Custom Fields |
 
-> **_NOTE_**: VLAN and VLAN Group will be turned on within the next available releases.
+NOTE - More information about Extensibility Attributes can be found in the [project documentation](#project-documentation).
 
 ### DiffSyncModel - Network
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,3 +15,34 @@ TODO: Write plugin documentation, the outline here is provided as a guide and sh
 ## Views
 
 ## Models
+
+## Extensibility Attributes
+
+Extensibility Attributes in Infoblox are a method of adding additional contextual information to objects in Infoblox. The closest analog in Nautobot is a Custom Field so this information has been imported as such. There is also an effort to attempt to match the information in these fields where possible to available objects in Nautobot. These available links are noted below:
+
+### Network (Prefixes)
+
+- Site/Facility
+- VRF
+- Role
+- Tenant/Department
+
+### IP Address
+
+- VRF
+- Role
+- Tenant/Department
+
+### VLAN Group
+
+- Site/Facility
+
+### VLAN
+
+- Site/Facility
+- Role
+- Tenant/Department
+
+### Aggregate
+
+- Tenant/Department

--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -6,6 +6,7 @@ from diffsync import DiffSync
 from diffsync.enum import DiffSyncFlags
 from nautobot.extras.plugins.exceptions import PluginImproperlyConfigured
 from nautobot_ssot_infoblox.utils.client import InfobloxApi
+from nautobot_ssot_infoblox.utils.diffsync import get_ext_attr_dict
 from nautobot_ssot_infoblox.diffsync.models.infoblox import (
     InfobloxAggregate,
     InfobloxIPAddress,
@@ -57,6 +58,7 @@ class InfobloxAdapter(DiffSync):
                 network=_pf["network"],
                 description=_pf.get("comment", ""),
                 status=_pf.get("status", "active"),
+                ext_attrs=get_ext_attr_dict(extattrs=_pf.get("extattrs", {})),
             )
             self.add(new_pf)
 
@@ -72,6 +74,7 @@ class InfobloxAdapter(DiffSync):
                     dns_name=_ip["names"][0],
                     status=self.conn.get_ipaddr_status(_ip),
                     description=_ip["comment"],
+                    ext_attrs=get_ext_attr_dict(extattrs=_ip.get("extattrs", {})),
                 )
                 self.add(new_ip)
 
@@ -81,6 +84,7 @@ class InfobloxAdapter(DiffSync):
             new_vv = self.vlangroup(
                 name=_vv["name"],
                 description=_vv["comment"] if _vv.get("comment") else "",
+                ext_attrs=get_ext_attr_dict(extattrs=_vv.get("extattrs", {})),
             )
             self.add(new_vv)
 
@@ -94,6 +98,7 @@ class InfobloxAdapter(DiffSync):
                 status=_vlan["status"],
                 vlangroup=vlan_group.group(1) if vlan_group else "",
                 description=_vlan["comment"] if _vlan.get("comment") else "",
+                ext_attrs=get_ext_attr_dict(extattrs=_vlan.get("extattrs", {})),
             )
             self.add(new_vlan)
 
@@ -136,5 +141,6 @@ class InfobloxAggregateAdapter(DiffSync):
                 new_aggregate = self.aggregate(
                     network=container["network"],
                     description=container["comment"] if container.get("comment") else "",
+                    ext_attrs=container.get("extattrs", {}),
                 )
                 self.add(new_aggregate)

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -101,10 +101,20 @@ class NautobotAdapter(NautobotMixin, DiffSync):
         """Load Prefixes from Nautobot."""
         all_prefixes = list(chain(Prefix.objects.all(), Aggregate.objects.all()))
         for prefix in all_prefixes:
+            # Reset CustomFields for Nautobot objects to blank if they failed to get linked originally.
+            if prefix.site is None:
+                prefix.custom_field_data["site"] = ""
+            if prefix.vrf is None:
+                prefix.custom_field_data["vrf"] = ""
+            if prefix.role is None:
+                prefix.custom_field_data["role"] = ""
+            if prefix.tenant is None:
+                prefix.custom_field_data["tenant"] = ""
             _prefix = self.prefix(
                 network=str(prefix.prefix),
                 description=prefix.description,
                 status=prefix.status.slug if hasattr(prefix, "status") else "container",
+                ext_attrs=prefix.custom_field_data,
                 pk=prefix.id,
             )
             try:
@@ -115,6 +125,14 @@ class NautobotAdapter(NautobotMixin, DiffSync):
     def load_ipaddresses(self):
         """Load IP Addresses from Nautobot."""
         for ipaddr in IPAddress.objects.all():
+            # Reset CustomFields for Nautobot objects to blank if they failed to get linked originally.
+            if ipaddr.vrf is None:
+                ipaddr.custom_field_data["vrf"] = ""
+            if ipaddr.role is None:
+                ipaddr.custom_field_data["role"] = ""
+            if ipaddr.tenant is None:
+                ipaddr.custom_field_data["tenant"] = ""
+
             addr = ipaddr.host
             # the last Prefix is the most specific and is assumed the one the IP address resides in
             prefix = Prefix.objects.net_contains(addr).last()
@@ -142,6 +160,7 @@ class NautobotAdapter(NautobotMixin, DiffSync):
                     prefix_length=prefix.prefix_length if prefix else ipaddr.prefix_length,
                     dns_name=ipaddr.dns_name,
                     description=ipaddr.description,
+                    ext_attrs=ipaddr.custom_field_data,
                     pk=ipaddr.id,
                 )
                 try:
@@ -152,18 +171,30 @@ class NautobotAdapter(NautobotMixin, DiffSync):
     def load_vlangroups(self):
         """Load VLAN Groups from Nautobot."""
         for grp in VLANGroup.objects.all():
-            _vg = self.vlangroup(name=grp.name, description=grp.description, pk=grp.id)
+            # Reset CustomFields for Nautobot objects to blank if they failed to get linked originally.
+            if grp.site is None:
+                grp.custom_field_data["site"] = ""
+            _vg = self.vlangroup(name=grp.name, description=grp.description, ext_attrs=grp.custom_field_data, pk=grp.id)
             self.add(_vg)
 
     def load_vlans(self):
         """Load VLANs from Nautobot."""
         for vlan in VLAN.objects.all():
+            # Reset CustomFields for Nautobot objects to blank if they failed to get linked originally.
+            if vlan.site is None:
+                vlan.custom_field_data["site"] = ""
+            if vlan.role is None:
+                vlan.custom_field_data["role"] = ""
+            if vlan.tenant is None:
+                vlan.custom_field_data["tenant"] = ""
+
             _vlan = self.vlan(
                 vid=vlan.vid,
                 name=vlan.name,
                 description=vlan.description,
                 vlangroup=vlan.group.name if vlan.group else "",
                 status=nautobot_vlan_status(vlan.status.name),
+                ext_attrs=vlan.custom_field_data,
                 pk=vlan.id,
             )
             self.add(_vlan)
@@ -197,7 +228,14 @@ class NautobotAggregateAdapter(NautobotMixin, DiffSync):
     def load(self):
         """Load aggregate models from Nautobot."""
         for aggregate in Aggregate.objects.all():
+            # Reset CustomFields for Nautobot objects to blank if they failed to get linked originally.
+            if aggregate.tenant is None:
+                aggregate.custom_field_data["tenant"] = ""
+
             _aggregate = self.aggregate(
-                network=str(aggregate.prefix), description=aggregate.description, pk=aggregate.id
+                network=str(aggregate.prefix),
+                description=aggregate.description,
+                ext_attrs=aggregate.custom_field_data,
+                pk=aggregate.id,
             )
             self.add(_aggregate)

--- a/nautobot_ssot_infoblox/diffsync/models/base.py
+++ b/nautobot_ssot_infoblox/diffsync/models/base.py
@@ -9,11 +9,12 @@ class Network(DiffSyncModel):
 
     _modelname = "prefix"
     _identifiers = ("network",)
-    _attributes = ("description",)
+    _attributes = ("description", "status", "ext_attrs")
 
     network: str
     description: Optional[str]
     status: Optional[str]
+    ext_attrs: Optional[dict]
     pk: Optional[uuid.UUID] = None
 
 
@@ -22,10 +23,11 @@ class VlanView(DiffSyncModel):
 
     _modelname = "vlangroup"
     _identifiers = ("name",)
-    _attributes = ("description",)
+    _attributes = ("description", "ext_attrs")
 
     name: str
     description: Optional[str]
+    ext_attrs: Optional[dict]
     pk: Optional[uuid.UUID] = None
 
 
@@ -34,13 +36,14 @@ class Vlan(DiffSyncModel):
 
     _modelname = "vlan"
     _identifiers = ("vid", "name", "vlangroup")
-    _attributes = ("description", "status")
+    _attributes = ("description", "status", "ext_attrs")
 
     vid: int
     name: str
     status: str
     description: Optional[str]
     vlangroup: Optional[str]
+    ext_attrs: Optional[dict]
     pk: Optional[uuid.UUID] = None
 
 
@@ -50,7 +53,7 @@ class IPAddress(DiffSyncModel):
     _modelname = "ipaddress"
     _identifiers = ("address", "prefix", "prefix_length")
     _shortname = ("address",)
-    _attributes = ("description", "dns_name", "status")
+    _attributes = ("description", "dns_name", "status", "ext_attrs")
 
     address: str
     dns_name: str
@@ -58,6 +61,7 @@ class IPAddress(DiffSyncModel):
     prefix_length: int
     status: Optional[str]
     description: Optional[str]
+    ext_attrs: Optional[dict]
     pk: Optional[uuid.UUID] = None
 
 
@@ -66,8 +70,9 @@ class Aggregate(DiffSyncModel):
 
     _modelname = "aggregate"
     _identifiers = ("network",)
-    _attributes = ("description",)
+    _attributes = ("description", "ext_attrs")
 
     network: str
     description: Optional[str]
+    ext_attrs: Optional[dict]
     pk: Optional[uuid.UUID] = None

--- a/nautobot_ssot_infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/models/nautobot.py
@@ -1,14 +1,74 @@
 """Nautobot Models for Infoblox integration with SSoT plugin."""
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.utils.text import slugify
+from nautobot.extras.choices import CustomFieldTypeChoices
+from nautobot.extras.models import CustomField as OrmCF
 from nautobot.extras.models import Status as OrmStatus
+from nautobot.dcim.models import Site as OrmSite
+from nautobot.ipam.choices import IPAddressRoleChoices
 from nautobot.ipam.models import RIR
 from nautobot.ipam.models import Aggregate as OrmAggregate
 from nautobot.ipam.models import IPAddress as OrmIPAddress
 from nautobot.ipam.models import Prefix as OrmPrefix
+from nautobot.ipam.models import Role as OrmPrefixRole
 from nautobot.ipam.models import VLAN as OrmVlan
 from nautobot.ipam.models import VLANGroup as OrmVlanGroup
+from nautobot.ipam.models import VRF as OrmVRF
+from nautobot.tenancy.models import Tenant as OrmTenant
 from nautobot_ssot_infoblox.diffsync.models.base import Aggregate, Network, IPAddress, Vlan, VlanView
 from nautobot_ssot_infoblox.utils.diffsync import create_tag_sync_from_infoblox
+
+
+def process_ext_attrs(diffsync, obj: object, extattrs: dict):
+    """Process Extensibility Attributes into Custom Fields or link to found objects.
+
+    Args:
+        diffsync (object): DiffSync Job
+        obj (object): The object that's being created or updated and needs processing.
+        extattrs (dict): The Extensibility Attributes to be analyzed and applied to passed `prefix`.
+    """
+    for attr, attr_value in extattrs.items():
+        if attr.lower() in ["site", "facility"]:
+            try:
+                obj.site = OrmSite.objects.get(name=attr_value)
+            except OrmSite.DoesNotExist as err:
+                diffsync.job.log_warning(
+                    message=f"Unable to find Site {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"
+                )
+        if attr.lower() == "vrf":
+            try:
+                obj.vrf = OrmVRF.objects.get(name=attr_value)
+            except OrmVRF.DoesNotExist as err:
+                diffsync.job.log_warning(
+                    message=f"Unable to find VRF {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"
+                )
+        if "role" in attr.lower():
+            if isinstance(obj, OrmIPAddress) and attr_value.lower() in IPAddressRoleChoices.as_dict():
+                obj.role = attr_value.lower()
+            else:
+                try:
+                    obj.role = OrmPrefixRole.objects.get(name=attr_value)
+                except OrmPrefixRole.DoesNotExist as err:
+                    diffsync.job.log_warning(
+                        message=f"Unable to find Role {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"
+                    )
+
+        if attr.lower() in ["tenant", "dept", "department"]:
+            try:
+                obj.tenant = OrmTenant.objects.get(name=attr_value)
+            except OrmTenant.DoesNotExist as err:
+                diffsync.job.log_warning(
+                    message=f"Unable to find Tenant {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"
+                )
+        _cf_dict = {
+            "name": slugify(attr),
+            "type": CustomFieldTypeChoices.TYPE_TEXT,
+            "label": attr,
+        }
+        field, _ = OrmCF.objects.get_or_create(name=_cf_dict["name"], defaults=_cf_dict)
+        field.content_types.add(ContentType.objects.get_for_model(type(obj)).id)
+        obj.custom_field_data.update({_cf_dict["name"]: attr_value})
 
 
 class NautobotNetwork(Network):
@@ -27,22 +87,28 @@ class NautobotNetwork(Network):
             status=status,
             description=attrs.get("description", ""),
         )
+        if attrs.get("ext_attrs"):
+            process_ext_attrs(diffsync=diffsync, obj=_prefix, extattrs=attrs["ext_attrs"])
         _prefix.tags.add(create_tag_sync_from_infoblox())
         _prefix.validated_save()
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
 
     def update(self, attrs):
         """Update Prefix object in Nautobot."""
-        _pf = OrmPrefix.objects.get(prefix=self.network)
-        if attrs.get("description"):
+        _pf = OrmPrefix.objects.get(id=self.pk)
+        if "description" in attrs:
             _pf.description = attrs["description"]
+        if "status" in attrs:
+            _pf.status = OrmStatus.objects.get(slug=attrs["status"])
+        if "ext_attrs" in attrs:
+            process_ext_attrs(diffsync=self.diffsync, obj=_pf, extattrs=attrs["ext_attrs"])
         _pf.validated_save()
         return super().update(attrs)
 
     # def delete(self):
     #     """Delete Prefix object in Nautobot."""
-    #     self.diffsync.job.log_warning(f"Prefix {self.network} will be deleted.")
-    #     _prefix = OrmPrefix.objects.get(prefix=self.get_identifiers()["network"])
+    #     self.diffsync.job.log_warning(message=f"Prefix {self.network} will be deleted.")
+    #     _prefix = OrmPrefix.objects.get(id=self.pk)
     #     _prefix.delete()
     #     return super().delete()
 
@@ -63,26 +129,29 @@ class NautobotIPAddress(IPAddress):
             dns_name=attrs.get("dns_name", ""),
         )
         _ip.tags.add(create_tag_sync_from_infoblox())
+        if attrs.get("ext_attrs"):
+            process_ext_attrs(diffsync=diffsync, obj=_ip, extattrs=attrs["ext_attrs"])
         _ip.validated_save()
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
 
     def update(self, attrs):
         """Update IPAddress object in Nautobot."""
-        _ipaddr = OrmIPAddress.objects.get(address=f"{self.address}/{self.prefix_length}")
+        _ipaddr = OrmIPAddress.objects.get(id=self.pk)
         if attrs.get("status"):
             _ipaddr.status = OrmStatus.objects.get(name=attrs["status"])
         if attrs.get("description"):
             _ipaddr.description = attrs["description"]
         if attrs.get("dns_name"):
             _ipaddr.dns_name = attrs["dns_name"]
+        if "ext_attrs" in attrs:
+            process_ext_attrs(diffsync=self.diffsync, obj=_ipaddr, extattrs=attrs["ext_attrs"])
         _ipaddr.validated_save()
         return super().update(attrs)
 
     # def delete(self):
     #     """Delete IPAddress object in Nautobot."""
     #     self.diffsync.job.log_warning(self, message=f"IP Address {self.address} will be deleted.")
-    #     ip_ids = self.get_identifiers()
-    #     _ipaddr = OrmIPAddress.objects.get(address=f"{ip_ids['address']}/{ip_ids['prefix_length']}")
+    #     _ipaddr = OrmIPAddress.objects.get(id=self.pk)
     #     _ipaddr.delete()
     #     return super().delete()
 
@@ -98,13 +167,22 @@ class NautobotVlanGroup(VlanView):
             slug=slugify(ids["name"]),
             description=attrs["description"],
         )
+        if attrs.get("ext_attrs"):
+            process_ext_attrs(diffsync=diffsync, obj=_vg, extattrs=attrs["ext_attrs"])
         _vg.validated_save()
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
+
+    def update(self, attrs):
+        """Update VLANGroup object in Nautobot."""
+        _vg = OrmVlanGroup.objects.get(id=self.pk)
+        if "ext_attrs" in attrs:
+            process_ext_attrs(diffsync=self.diffsync, obj=_vg, extattrs=attrs["ext_attrs"])
+        return super().update(attrs)
 
     def delete(self):
         """Delete VLANGroup object in Nautobot."""
         self.diffsync.job.log_warning(message=f"VLAN Group {self.name} will be deleted.")
-        _vg = OrmVlanGroup.objects.get(**self.get_identifiers())
+        _vg = OrmVlanGroup.objects.get(id=self.pk)
         _vg.delete()
         return super().delete()
 
@@ -122,8 +200,20 @@ class NautobotVlan(Vlan):
             group=OrmVlanGroup.objects.get(name=ids["vlangroup"]) if ids["vlangroup"] else None,
             description=attrs["description"],
         )
-        _vlan.tags.add("SSoT Synced to Infoblox")
-        _vlan.validated_save()
+        if "ext_attrs" in attrs:
+            process_ext_attrs(diffsync=diffsync, obj=_vlan, extattrs=attrs["ext_attrs"])
+        _vlan.tags.add(create_tag_sync_from_infoblox())
+        # ensure that the VLAN Group and VLAN have the same Site
+        if not _vlan.site and _vlan.group.site:
+            _vlan.site = _vlan.group.site
+        if not _vlan.group.site and _vlan.site:
+            _vlan.group.site = _vlan.site
+            _vlan.group.validated_save()
+        try:
+            _vlan.validated_save()
+        except ValidationError as err:
+            diffsync.job.log_warning(message=f"Unable to create VLAN {ids['name']} {ids['vid']}. {err}")
+            return False
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
 
     @staticmethod
@@ -138,18 +228,27 @@ class NautobotVlan(Vlan):
 
     def update(self, attrs):
         """Update VLAN object in Nautobot."""
-        _vlan = OrmVlan.objects.get(vid=self.vid)
+        _vlan = OrmVlan.objects.get(id=self.pk)
         if attrs.get("status"):
             _vlan.status = OrmStatus.objects.get(name=self.get_vlan_status(attrs["status"]))
         if attrs.get("description"):
             _vlan.description = attrs["description"]
-        _vlan.validated_save()
+        if "ext_attrs" in attrs:
+            process_ext_attrs(diffsync=self.diffsync, obj=_vlan, extattrs=attrs["ext_attrs"])
+        if not _vlan.group.site and _vlan.site:
+            _vlan.group.site = _vlan.site
+            _vlan.group.validated_save()
+        try:
+            _vlan.validated_save()
+        except ValidationError as err:
+            self.diffsync.job.log_warning(message=f"Unable to update VLAN {_vlan.name} {_vlan.vid}. {err}")
+            return False
         return super().update(attrs)
 
     def delete(self):
         """Delete VLAN object in Nautobot."""
         self.diffsync.job.log_warning(message=f"VLAN {self.vid} will be deleted.")
-        _vlan = OrmVlan.objects.get(vid=self.get_identifiers()["vid"])
+        _vlan = OrmVlan.objects.get(id=self.pk)
         _vlan.delete()
         return super().delete()
 
@@ -166,21 +265,25 @@ class NautobotAggregate(Aggregate):
             rir=rir,
             description=attrs["description"] if attrs.get("description") else "",
         )
-        _aggregate.tags.add("SSoT Synced to Infoblox")
+        if "ext_attrs" in attrs["ext_attrs"]:
+            process_ext_attrs(diffsync=diffsync, obj=_aggregate, extattrs=attrs["ext_attrs"])
+        _aggregate.tags.add(create_tag_sync_from_infoblox())
         _aggregate.validated_save()
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
 
     def update(self, attrs):
         """Update Aggregate object in Nautobot."""
-        _aggregate = OrmAggregate.objects.get(prefix=self.network)
+        _aggregate = OrmAggregate.objects.get(id=self.pk)
         if attrs.get("description"):
             _aggregate.description = attrs["description"]
+        if "ext_attrs" in attrs["ext_attrs"]:
+            process_ext_attrs(diffsync=self.diffsync, obj=_aggregate, extattrs=attrs["ext_attrs"])
         _aggregate.validated_save()
         return super().update(attrs)
 
     # def delete(self):
     #     """Delete Aggregate object in Nautobot."""
     #     self.diffsync.job.log_warning(message=f"Aggregate {self.network} will be deleted.")
-    #     _aggregate = OrmAggregate.objects.get(prefix=self.get_identifiers()["network"])
+    #     _aggregate = OrmAggregate.objects.get(id=self.pk)
     #     _aggregate.delete()
     #     return super().delete()

--- a/nautobot_ssot_infoblox/tests/test_utils.py
+++ b/nautobot_ssot_infoblox/tests/test_utils.py
@@ -1,7 +1,7 @@
 """Util tests that do not require Django."""
 import unittest
 
-from nautobot_ssot_infoblox.utils.diffsync import get_vlan_view_name, nautobot_vlan_status
+from nautobot_ssot_infoblox.utils.diffsync import get_vlan_view_name, nautobot_vlan_status, get_ext_attr_dict
 
 
 class TestUtils(unittest.TestCase):
@@ -18,3 +18,10 @@ class TestUtils(unittest.TestCase):
         """Test nautobot_vlan_status."""
         status = nautobot_vlan_status("Active")
         self.assertEqual(status, "ASSIGNED")
+
+    def test_get_ext_attr_dict(self):
+        """Test get_ext_attr_dict."""
+        test_dict = {"Site": {"value": "HQ"}, "Region": {"value": "Central"}}
+        expected = {"site": "HQ", "region": "Central"}
+        standardized_dict = get_ext_attr_dict(test_dict)
+        self.assertEqual(standardized_dict, expected)

--- a/nautobot_ssot_infoblox/utils/client.py
+++ b/nautobot_ssot_infoblox/utils/client.py
@@ -185,6 +185,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
         [
             {
                 "_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.220.0.100",
+                "extattrs": {"Usage": {"value": "TACACS"}},
                 "ip_address": "10.220.0.100",
                 "is_conflict": false,
                 "lease_state": "FREE",
@@ -206,6 +207,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
             },
             {
                 "_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAxLzA:10.220.0.101",
+                "extattrs": {},
                 "ip_address": "10.220.0.101",
                 "is_conflict": false,
                 "lease_state": "FREE",
@@ -239,7 +241,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
                     "object": "ipv4address",
                     "data": {"network_view": prefix[1], "network": prefix[0], "status": "USED"},
                     "args": {
-                        "_return_fields": "ip_address,mac_address,names,network,objects,status,types,usage,comment"
+                        "_return_fields": "ip_address,mac_address,names,network,objects,status,types,usage,comment,extattrs"
                     },
                 }
             )
@@ -663,18 +665,26 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
         [
             {
                 "_ref": "network/ZG5zLm5ldHdvcmskMTAuMjIzLjAuMC8yMS8w:10.223.0.0/21/default",
+                "extattrs": {},
                 "network": "10.223.0.0/21",
-                "network_view": "default"
+                "network_view": "default",
+                "rir": "NONE",
             },
             {
                 "_ref": "network/ZG5zLm5ldHdvcmskMTAuMjIwLjY0LjAvMjEvMA:10.220.64.0/21/default",
+                "extattrs": {},
                 "network": "10.220.64.0/21",
-                "network_view": "default"
+                "network_view": "default",
+                "rir": "NONE",
             },
         ]
         """
         url_path = "network"
-        params = {"_return_as_object": 1, "_return_fields": "network,network_view,comment", "_max_results": 10000}
+        params = {
+            "_return_as_object": 1,
+            "_return_fields": "network,network_view,comment,extattrs,rir_organization,rir",
+            "_max_results": 10000,
+        }
 
         if prefix:
             params.update({"network": prefix})
@@ -957,12 +967,14 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
         [
             {
                 "_ref": "vlanview/ZG5zLnZsYW5fdmlldyRWTFZpZXcxLjEwLjIw:VLView1/10/20",
+                "extattrs": {},
                 "end_vlan_id": 20,
                 "name": "VLView1",
                 "start_vlan_id": 10
             },
             {
                 "_ref": "vlanview/ZG5zLnZsYW5fdmlldyROYXV0b2JvdC4xLjQwOTQ:Nautobot/1/4094",
+                "extattrs": {},
                 "end_vlan_id": 4094,
                 "name": "Nautobot",
                 "start_vlan_id": 1
@@ -970,7 +982,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
         ]
         """
         url_path = "vlanview"
-        params = {"_return_fields": "name,comment,start_vlan_id,end_vlan_id"}
+        params = {"_return_fields": "name,comment,start_vlan_id,end_vlan_id,extattrs"}
         response = self._request("GET", url_path, params=params)
         logger.info(response.json())
         return response.json()
@@ -985,6 +997,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
         [
             {
                 "_ref": "vlan/ZG5zLnZsYW4kLmNvbS5pbmZvYmxveC5kbnMudmxhbl92aWV3JGRlZmF1bHQuMS40MDk0LjIw:default/DATA_VLAN/20",
+                "extattrs": {},
                 "assigned_to": [
                     "network/ZG5zLm5ldHdvcmskMTkyLjE2OC4xLjAvMjQvMA:192.168.1.0/24/default"
                 ],
@@ -996,6 +1009,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
             },
             {
                 "_ref": "vlan/ZG5zLnZsYW4kLmNvbS5pbmZvYmxveC5kbnMudmxhbl92aWV3JGRlZmF1bHQuMS40MDk0Ljk5:default/VOICE_VLAN/99",
+                "extattrs": {},
                 "comment": "Only Cisco IP Phones",
                 "id": 99,
                 "name": "VOICE_VLAN",
@@ -1013,7 +1027,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
                     "data": {},
                     "args": {
                         "_max_results": 100000000,
-                        "_return_fields": "assigned_to,id,name,comment,contact,department,description,reserved,status",
+                        "_return_fields": "assigned_to,id,name,comment,contact,department,description,reserved,status,extattrs",
                     },
                 }
             ]
@@ -1114,14 +1128,20 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
         [
             {
                 "_ref": "networkcontainer/ZG5zLm5ldHdvcmtfY29udGFpbmVyJDE5Mi4xNjguMi4wLzI0LzA:192.168.2.0/24/default",
+                "comment": "Campus LAN",
+                "extattrs": {},
                 "network": "192.168.2.0/24",
-                "network_view": "default"
+                "network_view": "default",
+                "rir": "NONE",
             }
         ]
         """
         url_path = "networkcontainer"
-        # params = {"_return_as_object": 1, "_return_fields": "network,comment,network_view", "_max_results": 100000}
-        params = {"_return_as_object": 1, "_max_results": 100000}
+        params = {
+            "_return_as_object": 1,
+            "_return_fields": "network,comment,network_view,extattrs,rir_organization,rir",
+            "_max_results": 100000,
+        }
         response = self._request("GET", url_path, params=params)
         response = response.json()
         logger.info(response)

--- a/nautobot_ssot_infoblox/utils/diffsync.py
+++ b/nautobot_ssot_infoblox/utils/diffsync.py
@@ -1,5 +1,6 @@
 """Utilities for DiffSync related stuff."""
 
+from django.utils.text import slugify
 from nautobot.extras.models import Tag
 from nautobot_ssot_infoblox.constant import TAG_COLOR
 
@@ -40,3 +41,22 @@ def nautobot_vlan_status(status: str) -> str:
         "Reserved": "RESERVED",
     }
     return statuses[status]
+
+
+def get_ext_attr_dict(extattrs: dict):
+    """Rebuild Extensibility Attributes dict into standard k/v pattern.
+
+    The standard extattrs dict pattern is to have the dict look like so:
+
+    {<attribute_key>: {"value": <actual_value>}}
+
+    Args:
+        extattrs (dict): Extensibility Attributes dict for object.
+
+    Returns:
+        dict: Standardized dictionary for Extensibility Attributes.
+    """
+    fixed_dict = {}
+    for key, value in extattrs.items():
+        fixed_dict[slugify(key)] = value["value"]
+    return fixed_dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-ssot-infoblox"
-version = "0.5.2"
+version = "0.6.0"
 description = "Nautobot SSoT Infoblox"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
* docs: :memo: Remove strikethrough on VLAN&Group
* chore: 🚚 Move images to doc static folder
* chore: 🚚 Move utility files into appropriate folder

Moved utility files into folder named the same. Also consolidated utility methods into single file. Updated all imports and references.

* build: Bump project to 0.5.2
* feat: ✨ Add Extensibility Attributes to each base model attributes
* refactor: 🔥 Remove get_all_networks as dupe of get_all_subnets

The get_all_networks and get_all_subnets functions were doing the same query with the exception of one taking a prefix as a kwarg. I've combined these two functions and updated the references so only get_all_subnets is used and it supports defining a prefix.

Removed get_all_networks function.

* style: 🚨 Remove whitespace for black
* fix: 🐛 Set prefix to None so not required get_all_subnets

Forgot to set prefix to None so it isn't a required kwarg. This should fix the tests that were failing.

* feat: ✨ Added method to standardize Extensibility Attributes dict and test
* feat: ✨ Update adapters to load Extensibility Attributes/Custom Fields for diff
* feat: ✨ Update client functions to get Extensibiilty Attributes
* feat: ✨ Create function to process Extensibility Attributes for each model

Wrote a function for each model called process_ext_attrs that reviews all EAs passed and attempts to match them with other objects in Nautobot like VRF, Site, Previx/VLANRole, and Tenant. Then it will also create CustomFields on each object for each EA and record values there.

* docs: Fix image links to docs folder
* refactor: 🚚 Rename utilities to diffsync to clarify use

As these functions are for both Infoblox and Nautobot the name diffsync makes more sense to align with use. As we expand these moving to individual files for each would be warranted. This makes the naming with the util folder more sensible.

Rename utilities to diffsync so paths are changed and location of functions needs to be updated.

* fix: 🐛 Ensure that update/delete functions use object pk

All models have a pk attribute to store the ID of an object from Nautobot. We should always use this for the update and delete functions on these models to ensure we are always working with the correct object.

* revert: ⏪️ Revert change in #78

I was wrong, the Tag objects are accepted. I'm not sure why previously I had some error thrown for the way it was done. I've tested and confirmed that the old method still works with 1.3 so it must have been a fluke.

* fix: Make key a slug ot match CustomFields
* build: Bump to 0.6.0

Should have been a minor bump, not patch as new features added.

* docs: 📝 Add documentation around Extensibility Attributes
* refactor: Change Site to OrmSite
* refactor: ♻️ Extracted process_ext_attrs function into helper function

To reduce repeated code I've moved the process_ext_attrs function outside the models and updated it to work with all of them. Logging had to be simplified but should still provide enough information to fix what's wrong if needed.

* fix: 🐛 Fix missing links for updates

It was found that during an update run that linked objects could be missed if the Custom Fields have the data filled in even if the linked object wasn't found. This will reset those fields so that the diff lines up correctly and will force an update to link those missing objects.

* fix: 🐛 Ensure that Role for IPAddress uses RoleChoices

To ensure that we don't accidentally have a Prefix or VLAN try to use a Role that IPAddress has I've added a check to ensure that the object passed is an IPAddress.

Co-authored-by: Justin Drew <jdrew82@users.noreply.github.com>