### PR TITLE
Ensure CustomField value is a string

### DIFF
--- a/nautobot_ssot_infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/models/nautobot.py
@@ -68,7 +68,7 @@ def process_ext_attrs(diffsync, obj: object, extattrs: dict):
         }
         field, _ = OrmCF.objects.get_or_create(name=_cf_dict["name"], defaults=_cf_dict)
         field.content_types.add(ContentType.objects.get_for_model(type(obj)).id)
-        obj.custom_field_data.update({_cf_dict["name"]: attr_value})
+        obj.custom_field_data.update({_cf_dict["name"]: str(attr_value)})
 
 
 class NautobotNetwork(Network):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-ssot-infoblox"
-version = "0.6.0"
+version = "0.6.1"
 description = "Nautobot SSoT Infoblox"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
When running a test import against a customer instance it was found that if the value passed isn't a string it will cause the import to crash. This is just a temporary fix to resolve the issue until can work on getting the Custom Fields updated to match the types that are available in Extensibility Attributes, ie integer, list, etc.