### PR TITLE
Subnet to VLAN Mapping

### DIFF
--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -6,7 +6,7 @@ from diffsync import DiffSync
 from diffsync.enum import DiffSyncFlags
 from nautobot.extras.plugins.exceptions import PluginImproperlyConfigured
 from nautobot_ssot_infoblox.utils.client import InfobloxApi
-from nautobot_ssot_infoblox.utils.diffsync import get_ext_attr_dict
+from nautobot_ssot_infoblox.utils.diffsync import get_ext_attr_dict, build_vlan_map
 from nautobot_ssot_infoblox.diffsync.models.infoblox import (
     InfobloxAggregate,
     InfobloxIPAddress,
@@ -59,6 +59,7 @@ class InfobloxAdapter(DiffSync):
                 description=_pf.get("comment", ""),
                 status=_pf.get("status", "active"),
                 ext_attrs=get_ext_attr_dict(extattrs=_pf.get("extattrs", {})),
+                vlans=build_vlan_map(vlans=_pf["vlans"]),
             )
             self.add(new_pf)
 

--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -59,7 +59,7 @@ class InfobloxAdapter(DiffSync):
                 description=_pf.get("comment", ""),
                 status=_pf.get("status", "active"),
                 ext_attrs=get_ext_attr_dict(extattrs=_pf.get("extattrs", {})),
-                vlans=build_vlan_map(vlans=_pf["vlans"]),
+                vlans=build_vlan_map(vlans=_pf["vlans"]) if _pf.get("vlans") else {},
             )
             self.add(new_pf)
 

--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -24,7 +24,7 @@ class InfobloxAdapter(DiffSync):
     vlangroup = InfobloxVLANView
     vlan = InfobloxVLAN
 
-    top_level = ["prefix", "ipaddress", "vlangroup", "vlan"]
+    top_level = ["vlangroup", "vlan", "prefix", "ipaddress"]
 
     def __init__(self, *args, job=None, sync=None, conn=None, **kwargs):
         """Initialize Infoblox.

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -115,6 +115,7 @@ class NautobotAdapter(NautobotMixin, DiffSync):
                 description=prefix.description,
                 status=prefix.status.slug if hasattr(prefix, "status") else "container",
                 ext_attrs=prefix.custom_field_data,
+                vlans={prefix.vlan.vid: prefix.vlan.name},
                 pk=prefix.id,
             )
             try:

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -115,7 +115,7 @@ class NautobotAdapter(NautobotMixin, DiffSync):
                 description=prefix.description,
                 status=prefix.status.slug if hasattr(prefix, "status") else "container",
                 ext_attrs=prefix.custom_field_data,
-                vlans={prefix.vlan.vid: prefix.vlan.name},
+                vlans={prefix.vlan.vid: prefix.vlan.name} if hasattr(prefix, "vlan") else {},
                 pk=prefix.id,
             )
             try:

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -84,7 +84,7 @@ class NautobotAdapter(NautobotMixin, DiffSync):
     vlangroup = NautobotVlanGroup
     vlan = NautobotVlan
 
-    top_level = ["prefix", "ipaddress", "vlangroup", "vlan"]
+    top_level = ["vlangroup", "vlan", "prefix", "ipaddress"]
 
     def __init__(self, *args, job=None, sync=None, **kwargs):
         """Initialize Nautobot.

--- a/nautobot_ssot_infoblox/diffsync/models/base.py
+++ b/nautobot_ssot_infoblox/diffsync/models/base.py
@@ -9,12 +9,13 @@ class Network(DiffSyncModel):
 
     _modelname = "prefix"
     _identifiers = ("network",)
-    _attributes = ("description", "status", "ext_attrs")
+    _attributes = ("description", "status", "ext_attrs", "vlans")
 
     network: str
     description: Optional[str]
     status: Optional[str]
     ext_attrs: Optional[dict]
+    vlans: Optional[dict]
     pk: Optional[uuid.UUID] = None
 
 

--- a/nautobot_ssot_infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/models/nautobot.py
@@ -90,7 +90,7 @@ class NautobotNetwork(Network):
             status=status,
             description=attrs.get("description", ""),
         )
-        if attrs.get("vlans") and len(attrs["vlans"].keys()) >= 1:
+        if attrs.get("vlans"):
             relationship_dict = {
                 "name": "Prefix -> VLAN",
                 "slug": "prefix_to_vlan",

--- a/nautobot_ssot_infoblox/utils/client.py
+++ b/nautobot_ssot_infoblox/utils/client.py
@@ -669,6 +669,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
                 "network": "10.223.0.0/21",
                 "network_view": "default",
                 "rir": "NONE",
+                "vlans": [],
             },
             {
                 "_ref": "network/ZG5zLm5ldHdvcmskMTAuMjIwLjY0LjAvMjEvMA:10.220.64.0/21/default",
@@ -676,13 +677,14 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
                 "network": "10.220.64.0/21",
                 "network_view": "default",
                 "rir": "NONE",
+                "vlans": [],
             },
         ]
         """
         url_path = "network"
         params = {
             "_return_as_object": 1,
-            "_return_fields": "network,network_view,comment,extattrs,rir_organization,rir",
+            "_return_fields": "network,network_view,comment,extattrs,rir_organization,rir,vlans",
             "_max_results": 10000,
         }
 

--- a/nautobot_ssot_infoblox/utils/diffsync.py
+++ b/nautobot_ssot_infoblox/utils/diffsync.py
@@ -60,3 +60,18 @@ def get_ext_attr_dict(extattrs: dict):
     for key, value in extattrs.items():
         fixed_dict[slugify(key)] = value["value"]
     return fixed_dict
+
+
+def build_vlan_map(vlans: list):
+    """Build map of VLAN ID to VLAN name.
+
+    Args:
+        vlans (list): List of VLANs assigned to 
+
+    Returns:
+        dict: Dictionary mapping VLAN ID to VLAN name.
+    """
+    map = {}
+    for vlan in vlans:
+        map[vlan["id"]] = vlan["name"]
+    return map

--- a/nautobot_ssot_infoblox/utils/diffsync.py
+++ b/nautobot_ssot_infoblox/utils/diffsync.py
@@ -66,12 +66,12 @@ def build_vlan_map(vlans: list):
     """Build map of VLAN ID to VLAN name.
 
     Args:
-        vlans (list): List of VLANs assigned to 
+        vlans (list): List of VLANs assigned to
 
     Returns:
-        dict: Dictionary mapping VLAN ID to VLAN name.
+        dict: Dictionary mapping VLAN ID to VLAN name, VLAN ID, and VLAN View (group).
     """
-    map = {}
+    vlan_map = {}
     for vlan in vlans:
-        map[vlan["id"]] = vlan["name"]
-    return map
+        vlan_map[vlan["id"]] = {"vid": vlan["id"], "name": vlan["name"], "group": get_vlan_view_name(vlan["vlan"])}
+    return vlan_map

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-ssot-infoblox"
-version = "0.6.1"
+version = "0.7.0"
 description = "Nautobot SSoT Infoblox"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This PR covers the FR in #87. One edge case that needs to be handled is the potential for more than one VLAN to be assigned to a Subnet. Nautobot doesn't allow for this but we can utilize Relationships to still provide that connection for the extra VLANs.