### PR TITLE
Add InfobloxApi Connection

### DIFF
--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -133,6 +133,12 @@ class InfobloxAggregateAdapter(DiffSync):
         self.sync = sync
         self.conn = conn
 
+        if self.conn in [None, False]:
+            self.job.log_failure(
+                message="Improperly configured settings for communicating to Infoblox. Please validate accuracy."
+            )
+            raise PluginImproperlyConfigured
+
     def load(self):
         """Load aggregate models."""
         for container in self.conn.get_network_containers():

--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -122,7 +122,7 @@ class InfobloxAggregateAdapter(DiffSync):
 
     top_level = ["aggregate"]
 
-    def __init__(self, *args, job=None, sync=None, **kwargs):
+    def __init__(self, *args, job=None, sync=None, conn=None, **kwargs):
         """Initialize Infoblox.
 
         Args:
@@ -132,7 +132,7 @@ class InfobloxAggregateAdapter(DiffSync):
         super().__init__(*args, **kwargs)
         self.job = job
         self.sync = sync
-        self.conn = InfobloxApi()
+        self.conn = conn
 
     def load(self):
         """Load aggregate models."""

--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -5,7 +5,6 @@ import re
 from diffsync import DiffSync
 from diffsync.enum import DiffSyncFlags
 from nautobot.extras.plugins.exceptions import PluginImproperlyConfigured
-from nautobot_ssot_infoblox.utils.client import InfobloxApi
 from nautobot_ssot_infoblox.utils.diffsync import get_ext_attr_dict, build_vlan_map
 from nautobot_ssot_infoblox.diffsync.models.infoblox import (
     InfobloxAggregate,

--- a/nautobot_ssot_infoblox/jobs.py
+++ b/nautobot_ssot_infoblox/jobs.py
@@ -96,7 +96,8 @@ class InfobloxDataTarget(DataTarget, Job):
     def load_target_adapter(self):
         """Load Infoblox data."""
         self.log_info(message="Connecting to Infoblox")
-        self.target_adapter = infoblox.InfobloxAdapter(job=self, sync=self.sync)
+        client = InfobloxApi()
+        self.target_adapter = infoblox.InfobloxAdapter(job=self, sync=self.sync, conn=client)
         self.log_info(message="Loading data from Infoblox...")
         self.target_adapter.load()
 
@@ -127,7 +128,8 @@ class InfobloxNetworkContainerSource(DataSource, Job):
     def load_source_adapter(self):
         """Load Infoblox data."""
         self.log_info(message="Connecting to Infoblox")
-        self.source_adapter = infoblox.InfobloxAggregateAdapter(job=self, sync=self.sync)
+        client = InfobloxApi()
+        self.source_adapter = infoblox.InfobloxAggregateAdapter(job=self, sync=self.sync, conn=client)
         self.log_info(message="Loading data from Infoblox...")
         self.source_adapter.load()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-ssot-infoblox"
-version = "0.7.2"
+version = "0.7.3"
 description = "Nautobot SSoT Infoblox"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This PR adds in the InfobloxApi connection object to the InfobloxAdapter that's required for the DataTarget and aggregate Jobs to function. This should fix #103.