### PR TITLE
Fix Extensibility Attributes Churn & Fix Prefix VLAN Updates

### DIFF
--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -127,6 +127,7 @@ class InfobloxAggregateAdapter(DiffSync):
         Args:
             job (object, optional): Infoblox job. Defaults to None.
             sync (object, optional): Infoblox DiffSync. Defaults to None.
+            conn (object): InfobloxAPI connection.
         """
         super().__init__(*args, **kwargs)
         self.job = job

--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -5,6 +5,7 @@ import re
 from diffsync import DiffSync
 from diffsync.enum import DiffSyncFlags
 from nautobot.extras.plugins.exceptions import PluginImproperlyConfigured
+from nautobot_ssot_infoblox.utils.client import get_default_ext_attrs
 from nautobot_ssot_infoblox.utils.diffsync import get_ext_attr_dict, build_vlan_map
 from nautobot_ssot_infoblox.diffsync.models.infoblox import (
     InfobloxAggregate,
@@ -52,21 +53,26 @@ class InfobloxAdapter(DiffSync):
         subnets = self.conn.get_all_subnets()
         self.subnets = [(x["network"], x["network_view"]) for x in subnets]
         all_networks = containers + subnets
+        default_ext_attrs = get_default_ext_attrs(review_list=all_networks)
         for _pf in all_networks:
+            pf_ext_attrs = get_ext_attr_dict(extattrs=_pf.get("extattrs", {}))
             new_pf = self.prefix(
                 network=_pf["network"],
                 description=_pf.get("comment", ""),
                 status=_pf.get("status", "active"),
-                ext_attrs=get_ext_attr_dict(extattrs=_pf.get("extattrs", {})),
+                ext_attrs={**default_ext_attrs, **pf_ext_attrs},
                 vlans=build_vlan_map(vlans=_pf["vlans"]) if _pf.get("vlans") else {},
             )
             self.add(new_pf)
 
     def load_ipaddresses(self):
         """Load InfobloxIPAddress DiffSync model."""
-        for _ip in self.conn.get_all_ipv4address_networks(prefixes=self.subnets):
+        ipaddrs = self.conn.get_all_ipv4address_networks(prefixes=self.subnets)
+        default_ext_attrs = get_default_ext_attrs(review_list=ipaddrs)
+        for _ip in ipaddrs:
             _, prefix_length = _ip["network"].split("/")
             if _ip["names"]:
+                ip_ext_attrs = get_ext_attr_dict(extattrs=_ip.get("extattrs", {}))
                 new_ip = self.ipaddress(
                     address=_ip["ip_address"],
                     prefix=_ip["network"],
@@ -74,23 +80,29 @@ class InfobloxAdapter(DiffSync):
                     dns_name=_ip["names"][0],
                     status=self.conn.get_ipaddr_status(_ip),
                     description=_ip["comment"],
-                    ext_attrs=get_ext_attr_dict(extattrs=_ip.get("extattrs", {})),
+                    ext_attrs={**default_ext_attrs, **ip_ext_attrs},
                 )
                 self.add(new_ip)
 
     def load_vlanviews(self):
         """Load InfobloxVLANView DiffSync model."""
-        for _vv in self.conn.get_vlanviews():
+        vlanviews = self.conn.get_vlanviews()
+        default_ext_attrs = get_default_ext_attrs(review_list=vlanviews)
+        for _vv in vlanviews:
+            vv_ext_attrs = get_ext_attr_dict(extattrs=_vv.get("extattrs", {}))
             new_vv = self.vlangroup(
                 name=_vv["name"],
                 description=_vv["comment"] if _vv.get("comment") else "",
-                ext_attrs=get_ext_attr_dict(extattrs=_vv.get("extattrs", {})),
+                ext_attrs={**default_ext_attrs, **vv_ext_attrs},
             )
             self.add(new_vv)
 
     def load_vlans(self):
         """Load InfobloxVlan DiffSync model."""
-        for _vlan in self.conn.get_vlans():
+        vlans = self.conn.get_vlans()
+        default_ext_attrs = get_default_ext_attrs(review_list=vlans)
+        for _vlan in vlans:
+            vlan_ext_attrs = get_ext_attr_dict(extattrs=_vlan.get("extattrs", {}))
             vlan_group = re.search(r"(?:.+\:)(\S+)(?:\/\S+\/.+)", _vlan["_ref"])
             new_vlan = self.vlan(
                 name=_vlan["name"],
@@ -98,7 +110,7 @@ class InfobloxAdapter(DiffSync):
                 status=_vlan["status"],
                 vlangroup=vlan_group.group(1) if vlan_group else "",
                 description=_vlan["comment"] if _vlan.get("comment") else "",
-                ext_attrs=get_ext_attr_dict(extattrs=_vlan.get("extattrs", {})),
+                ext_attrs={**default_ext_attrs, **vlan_ext_attrs},
             )
             self.add(new_vlan)
 
@@ -142,12 +154,15 @@ class InfobloxAggregateAdapter(DiffSync):
 
     def load(self):
         """Load aggregate models."""
-        for container in self.conn.get_network_containers():
+        containers = self.conn.get_network_containers()
+        default_ext_attrs = get_default_ext_attrs(review_list=containers)
+        for container in containers:
             network = ipaddress.ip_network(container["network"])
+            container_ext_attrs = get_ext_attr_dict(extattrs=container.get("extattrs", {}))
             if network.is_private and container["network"] in ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]:
                 new_aggregate = self.aggregate(
                     network=container["network"],
                     description=container["comment"] if container.get("comment") else "",
-                    ext_attrs=container.get("extattrs", {}),
+                    ext_attrs={**default_ext_attrs, **container_ext_attrs},
                 )
                 self.add(new_aggregate)

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -16,6 +16,7 @@ from nautobot_ssot_infoblox.diffsync.models import (
 )
 from nautobot_ssot_infoblox.constant import TAG_COLOR
 from nautobot_ssot_infoblox.utils.diffsync import nautobot_vlan_status, get_default_custom_fields
+from nautobot_ssot_infoblox.utils.nautobot import build_vlan_map_from_relations, get_prefix_vlans
 
 
 class NautobotMixin:
@@ -104,12 +105,13 @@ class NautobotAdapter(NautobotMixin, DiffSync):
         for prefix in all_prefixes:
             if "ssot-synced-to-infoblox" in prefix.custom_field_data:
                 prefix.custom_field_data.pop("ssot-synced-to-infoblox")
+            current_vlans = get_prefix_vlans(prefix=prefix)
             _prefix = self.prefix(
                 network=str(prefix.prefix),
                 description=prefix.description,
                 status=prefix.status.slug if hasattr(prefix, "status") else "container",
                 ext_attrs={**default_cfs, **prefix.custom_field_data},
-                vlans={prefix.vlan.vid: prefix.vlan.name} if prefix.vlan is not None else {},
+                vlans=build_vlan_map_from_relations(vlans=current_vlans),
                 pk=prefix.id,
             )
             try:

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -15,7 +15,7 @@ from nautobot_ssot_infoblox.diffsync.models import (
     NautobotVlan,
 )
 from nautobot_ssot_infoblox.constant import TAG_COLOR
-from nautobot_ssot_infoblox.utils.diffsync import nautobot_vlan_status
+from nautobot_ssot_infoblox.utils.diffsync import nautobot_vlan_status, get_default_custom_fields
 
 
 class NautobotMixin:
@@ -100,21 +100,15 @@ class NautobotAdapter(NautobotMixin, DiffSync):
     def load_prefixes(self):
         """Load Prefixes from Nautobot."""
         all_prefixes = list(chain(Prefix.objects.all(), Aggregate.objects.all()))
+        default_cfs = get_default_custom_fields(cf_contenttype=ContentType.objects.get_for_model(Prefix))
         for prefix in all_prefixes:
-            # Reset CustomFields for Nautobot objects to blank if they failed to get linked originally.
-            if prefix.site is None:
-                prefix.custom_field_data["site"] = ""
-            if prefix.vrf is None:
-                prefix.custom_field_data["vrf"] = ""
-            if prefix.role is None:
-                prefix.custom_field_data["role"] = ""
-            if prefix.tenant is None:
-                prefix.custom_field_data["tenant"] = ""
+            if "ssot-synced-to-infoblox" in prefix.custom_field_data:
+                prefix.custom_field_data.pop("ssot-synced-to-infoblox")
             _prefix = self.prefix(
                 network=str(prefix.prefix),
                 description=prefix.description,
                 status=prefix.status.slug if hasattr(prefix, "status") else "container",
-                ext_attrs=prefix.custom_field_data,
+                ext_attrs={**default_cfs, **prefix.custom_field_data},
                 vlans={prefix.vlan.vid: prefix.vlan.name} if prefix.vlan is not None else {},
                 pk=prefix.id,
             )
@@ -125,15 +119,8 @@ class NautobotAdapter(NautobotMixin, DiffSync):
 
     def load_ipaddresses(self):
         """Load IP Addresses from Nautobot."""
+        default_cfs = get_default_custom_fields(cf_contenttype=ContentType.objects.get_for_model(IPAddress))
         for ipaddr in IPAddress.objects.all():
-            # Reset CustomFields for Nautobot objects to blank if they failed to get linked originally.
-            if ipaddr.vrf is None:
-                ipaddr.custom_field_data["vrf"] = ""
-            if ipaddr.role is None:
-                ipaddr.custom_field_data["role"] = ""
-            if ipaddr.tenant is None:
-                ipaddr.custom_field_data["tenant"] = ""
-
             addr = ipaddr.host
             # the last Prefix is the most specific and is assumed the one the IP address resides in
             prefix = Prefix.objects.net_contains(addr).last()
@@ -154,6 +141,8 @@ class NautobotAdapter(NautobotMixin, DiffSync):
                 continue
 
             if ipaddr.dns_name:
+                if "ssot-synced-to-infoblox" in ipaddr.custom_field_data:
+                    ipaddr.custom_field_data.pop("ssot-synced-to-infoblox")
                 _ip = self.ipaddress(
                     address=addr,
                     prefix=str(prefix),
@@ -161,7 +150,7 @@ class NautobotAdapter(NautobotMixin, DiffSync):
                     prefix_length=prefix.prefix_length if prefix else ipaddr.prefix_length,
                     dns_name=ipaddr.dns_name,
                     description=ipaddr.description,
-                    ext_attrs=ipaddr.custom_field_data,
+                    ext_attrs={**default_cfs, **ipaddr.custom_field_data},
                     pk=ipaddr.id,
                 )
                 try:
@@ -171,31 +160,31 @@ class NautobotAdapter(NautobotMixin, DiffSync):
 
     def load_vlangroups(self):
         """Load VLAN Groups from Nautobot."""
+        default_cfs = get_default_custom_fields(cf_contenttype=ContentType.objects.get_for_model(VLANGroup))
         for grp in VLANGroup.objects.all():
-            # Reset CustomFields for Nautobot objects to blank if they failed to get linked originally.
-            if grp.site is None:
-                grp.custom_field_data["site"] = ""
-            _vg = self.vlangroup(name=grp.name, description=grp.description, ext_attrs=grp.custom_field_data, pk=grp.id)
+            if "ssot-synced-to-infoblox" in grp.custom_field_data:
+                grp.custom_field_data.pop("ssot-synced-to-infoblox")
+            _vg = self.vlangroup(
+                name=grp.name,
+                description=grp.description,
+                ext_attrs={**default_cfs, **grp.custom_field_data},
+                pk=grp.id,
+            )
             self.add(_vg)
 
     def load_vlans(self):
         """Load VLANs from Nautobot."""
+        default_cfs = get_default_custom_fields(cf_contenttype=ContentType.objects.get_for_model(VLAN))
         for vlan in VLAN.objects.all():
-            # Reset CustomFields for Nautobot objects to blank if they failed to get linked originally.
-            if vlan.site is None:
-                vlan.custom_field_data["site"] = ""
-            if vlan.role is None:
-                vlan.custom_field_data["role"] = ""
-            if vlan.tenant is None:
-                vlan.custom_field_data["tenant"] = ""
-
+            if "ssot-synced-to-infoblox" in vlan.custom_field_data:
+                vlan.custom_field_data.pop("ssot-synced-to-infoblox")
             _vlan = self.vlan(
                 vid=vlan.vid,
                 name=vlan.name,
                 description=vlan.description,
                 vlangroup=vlan.group.name if vlan.group else "",
                 status=nautobot_vlan_status(vlan.status.name),
-                ext_attrs=vlan.custom_field_data,
+                ext_attrs={**default_cfs, **vlan.custom_field_data},
                 pk=vlan.id,
             )
             self.add(_vlan)

--- a/nautobot_ssot_infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/models/nautobot.py
@@ -130,7 +130,7 @@ class NautobotNetwork(Network):
         _prefix.validated_save()
         return super().create(ids=ids, diffsync=diffsync, attrs=attrs)
 
-    def update(self, attrs):
+    def update(self, attrs):  # pylint: disable=too-many-branches
         """Update Prefix object in Nautobot."""
         _pf = OrmPrefix.objects.get(id=self.pk)
         if self.diffsync.job.kwargs.get("debug"):

--- a/nautobot_ssot_infoblox/utils/client.py
+++ b/nautobot_ssot_infoblox/utils/client.py
@@ -42,9 +42,9 @@ def get_default_ext_attrs(review_list: list) -> dict:
     default_ext_attrs = {}
     for item in review_list:
         pf_ext_attrs = get_ext_attr_dict(extattrs=item.get("extattrs", {}))
-        for k in pf_ext_attrs:
-            if k not in default_ext_attrs:
-                default_ext_attrs[k] = None
+        for attr in pf_ext_attrs:
+            if attr not in default_ext_attrs:
+                default_ext_attrs[attr] = None
     return default_ext_attrs
 
 

--- a/nautobot_ssot_infoblox/utils/client.py
+++ b/nautobot_ssot_infoblox/utils/client.py
@@ -11,6 +11,7 @@ from requests.compat import urljoin
 from dns import reversename
 from nautobot.core.settings_funcs import is_truthy
 from nautobot_ssot_infoblox.constant import PLUGIN_CFG
+from nautobot_ssot_infoblox.utils.diffsync import get_ext_attr_dict
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,24 @@ def parse_url(address):
     if not re.search(r"^[A-Za-z0-9+.\-]+://", address):
         address = f"https://{address}"
     return urllib.parse.urlparse(address)
+
+
+def get_default_ext_attrs(review_list: list) -> dict:
+    """Determine the default Extensibility Attributes for an object being processed.
+
+    Args:
+        review_list (list): The list of objects that need to be reviewed to gather default Extensibility Attributes.
+
+    Returns:
+        dict: Dictionary of default Extensibility Attributes for a VLAN View, VLANs, Prefixes, or IP Addresses.
+    """
+    default_ext_attrs = {}
+    for item in review_list:
+        pf_ext_attrs = get_ext_attr_dict(extattrs=item.get("extattrs", {}))
+        for k in pf_ext_attrs:
+            if k not in default_ext_attrs:
+                default_ext_attrs[k] = None
+    return default_ext_attrs
 
 
 class InvalidUrlScheme(Exception):

--- a/nautobot_ssot_infoblox/utils/diffsync.py
+++ b/nautobot_ssot_infoblox/utils/diffsync.py
@@ -86,10 +86,10 @@ def get_default_custom_fields(cf_contenttype: ContentType) -> dict:
     Returns:
         dict: Dictionary of all Custom Fields for a specific object type.
     """
-    cfs = CustomField.objects.filter(content_types=cf_contenttype)
+    customfields = CustomField.objects.filter(content_types=cf_contenttype)
     default_cfs = {}
-    for cf in cfs:
-        if cf.name != "ssot-synced-to-infoblox":
-            if cf.name not in default_cfs:
-                default_cfs[cf.name] = None
+    for customfield in customfields:
+        if customfield.name != "ssot-synced-to-infoblox":
+            if customfield.name not in default_cfs:
+                default_cfs[customfield.name] = None
     return default_cfs

--- a/nautobot_ssot_infoblox/utils/diffsync.py
+++ b/nautobot_ssot_infoblox/utils/diffsync.py
@@ -1,7 +1,7 @@
 """Utilities for DiffSync related stuff."""
-
+from django.contrib.contenttypes.models import ContentType
 from django.utils.text import slugify
-from nautobot.extras.models import Tag
+from nautobot.extras.models import CustomField, Tag
 from nautobot_ssot_infoblox.constant import TAG_COLOR
 
 
@@ -75,3 +75,21 @@ def build_vlan_map(vlans: list):
     for vlan in vlans:
         vlan_map[vlan["id"]] = {"vid": vlan["id"], "name": vlan["name"], "group": get_vlan_view_name(vlan["vlan"])}
     return vlan_map
+
+
+def get_default_custom_fields(cf_contenttype: ContentType) -> dict:
+    """Get default Custom Fields for specific ContentType.
+
+    Args:
+        cf_contenttype (ContentType): Specific ContentType to get all Custom Fields for.
+
+    Returns:
+        dict: Dictionary of all Custom Fields for a specific object type.
+    """
+    cfs = CustomField.objects.filter(content_types=cf_contenttype)
+    default_cfs = {}
+    for cf in cfs:
+        if cf.name != "ssot-synced-to-infoblox":
+            if cf.name not in default_cfs:
+                default_cfs[cf.name] = None
+    return default_cfs

--- a/nautobot_ssot_infoblox/utils/nautobot.py
+++ b/nautobot_ssot_infoblox/utils/nautobot.py
@@ -1,0 +1,31 @@
+"""Utility functions for working with Nautobot."""
+from nautobot.extras.models import Relationship
+from nautobot.ipam.models import Prefix
+
+
+def build_vlan_map_from_relations(vlans: list):
+    """Create a map of VLANs for a Prefix from a list.
+
+    The map should follow the pattern of {vlan_id: {"vid": vlan_id, "name": vlan_name, "group": vlan_group_name}}
+
+    Args:
+        vlans (list): List of VLANs that have a RelationshipAssociation to a Prefix.
+    """
+    vlan_map = {}
+    for vlan in vlans:
+        vlan_map[vlan.vid] = {"vid": vlan.vid, "name": vlan.name, "group": vlan.group.name}
+    return vlan_map
+
+
+def get_prefix_vlans(prefix: Prefix) -> list:
+    """Get list of current VLANs with RelationshipAssociation to a Prefix.
+
+    Args:
+        prefix (Prefix): Prefix to get list of current VLANs with RelationshipAssociation to Prefix.
+
+    Returns:
+        list: List of VLAN objects with RelationshipAssociation to passed Prefix.
+    """
+    pf_relations = prefix.get_relationships()
+    pf_vlan_relationship = Relationship.objects.get(name="Prefix -> VLAN")
+    return [x.destination for x in pf_relations["source"][pf_vlan_relationship]]


### PR DESCRIPTION
This PR is focused on fixing the "churn" or diff values not lining up for Extensibility Attributes as noted in #108. I've ensured that both adapters load the default set of relevant CustomFields and Extensibility Attributes so that they match in the diff. This should ensure that only actual changes occur.