### PR TITLE
Fix Prefix to VLAN Relationship

### DIFF
--- a/nautobot_ssot_infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/models/nautobot.py
@@ -92,18 +92,7 @@ class NautobotNetwork(Network):
             description=attrs.get("description", ""),
         )
         if attrs.get("vlans"):
-            relationship_dict = {
-                "name": "Prefix -> VLAN",
-                "slug": "prefix_to_vlan",
-                "type": RelationshipTypeChoices.TYPE_ONE_TO_MANY,
-                "source_type": ContentType.objects.get_for_model(OrmPrefix),
-                "source_label": "Prefix",
-                "destination_type": ContentType.objects.get_for_model(OrmVlan),
-                "destination_label": "VLAN",
-            }
-            relation, _ = OrmRelationship.objects.get_or_create(
-                name=relationship_dict["name"], defaults=relationship_dict
-            )
+            relation = OrmRelationship.objects.get(name="Prefix -> VLAN")
             for _, _vlan in attrs["vlans"].items():
                 index = 0
                 try:

--- a/nautobot_ssot_infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/models/nautobot.py
@@ -3,7 +3,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.utils.text import slugify
 from nautobot.extras.choices import CustomFieldTypeChoices
-from nautobot.extras.choices import RelationshipTypeChoices
 from nautobot.extras.models import Relationship as OrmRelationship
 from nautobot.extras.models import RelationshipAssociation as OrmRelationshipAssociation
 from nautobot.extras.models import CustomField as OrmCF

--- a/nautobot_ssot_infoblox/signals.py
+++ b/nautobot_ssot_infoblox/signals.py
@@ -1,7 +1,6 @@
 """Signal handlers for nautobot_ssot_infoblox."""
 
-
-from nautobot.extras.choices import CustomFieldTypeChoices
+from nautobot.extras.choices import CustomFieldTypeChoices, RelationshipTypeChoices
 from nautobot_ssot_infoblox.constant import TAG_COLOR
 
 
@@ -17,6 +16,8 @@ def nautobot_database_ready_callback(sender, *, apps, **kwargs):  # pylint: disa
     IPAddress = apps.get_model("ipam", "IPAddress")
     Aggregate = apps.get_model("ipam", "Aggregate")
     Tag = apps.get_model("extras", "Tag")
+    Relationship = apps.get_model("extras", "Relationship")
+    VLAN = apps.get_model("ipam", "VLAN")
 
     Tag.objects.get_or_create(
         slug="ssot-synced-from-infoblox",
@@ -47,3 +48,15 @@ def nautobot_database_ready_callback(sender, *, apps, **kwargs):  # pylint: disa
         ContentType.objects.get_for_model(Aggregate),
     ]:
         custom_field.content_types.add(content_type)
+
+    # add Prefix -> VLAN Relationship
+    relationship_dict = {
+        "name": "Prefix -> VLAN",
+        "slug": "prefix_to_vlan",
+        "type": RelationshipTypeChoices.TYPE_ONE_TO_MANY,
+        "source_type": ContentType.objects.get_for_model(Prefix),
+        "source_label": "Prefix",
+        "destination_type": ContentType.objects.get_for_model(VLAN),
+        "destination_label": "VLAN",
+    }
+    Relationship.objects.get_or_create(name=relationship_dict["name"], defaults=relationship_dict)


### PR DESCRIPTION
This fixes a bug detailed in #116. While testing the fix I noticed that a large number of attempts to find Site objects when the EA value was None. This should ensure that it only attempts to find something if a valid value.