### PR TITLE
fix: IP Address Bulk Import

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -307,6 +307,7 @@ PLUGINS_CONFIG = {
         "NAUTOBOT_INFOBLOX_WAPI_VERSION": os.getenv("NAUTOBOT_INFOBLOX_WAPI_VERSION", "v2.12"),
         "enable_sync_to_infoblox": True,
         "enable_rfc1918_network_containers": True,
+        "default_status": "active",
     },
     "nautobot_ssot": {
         "hide_example_jobs": True,

--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -119,13 +119,17 @@ class InfobloxAdapter(DiffSync):
     def load(self):
         """Load all models by calling other methods."""
         self.load_prefixes()
-        self.job.log(message=f"Loaded {len(self.dict()['prefix'])} prefixes from Infoblox.")
+        if "prefix" in self.dict():
+            self.job.log(message=f"Loaded {len(self.dict()['prefix'])} prefixes from Infoblox.")
         self.load_ipaddresses()
-        self.job.log(message=f"Loaded {len(self.dict()['ipaddress'])} IP addresses from Infoblox.")
+        if "ipaddress" in self.dict():
+            self.job.log(message=f"Loaded {len(self.dict()['ipaddress'])} IP addresses from Infoblox.")
         self.load_vlanviews()
-        self.job.log(message=f"Loaded {len(self.dict()['vlangroup'])} VLAN views from Infoblox.")
+        if "vlangroup" in self.dict():
+            self.job.log(message=f"Loaded {len(self.dict()['vlangroup'])} VLAN views from Infoblox.")
         self.load_vlans()
-        self.job.log(message=f"Loaded {len(self.dict()['vlan'])} VLANs from Infoblox.")
+        if "vlan" in self.dict():
+            self.job.log(message=f"Loaded {len(self.dict()['vlan'])} VLANs from Infoblox.")
 
     def sync_complete(self, source, diff, flags=DiffSyncFlags.NONE, logger=None):
         """Add tags and custom fields to synced objects."""

--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -5,7 +5,7 @@ import re
 from diffsync import DiffSync
 from diffsync.enum import DiffSyncFlags
 from nautobot.extras.plugins.exceptions import PluginImproperlyConfigured
-from nautobot_ssot_infoblox.utils.client import get_default_ext_attrs
+from nautobot_ssot_infoblox.utils.client import get_default_ext_attrs, get_dns_name
 from nautobot_ssot_infoblox.utils.diffsync import get_ext_attr_dict, build_vlan_map
 from nautobot_ssot_infoblox.diffsync.models.infoblox import (
     InfobloxAggregate,
@@ -71,18 +71,20 @@ class InfobloxAdapter(DiffSync):
         default_ext_attrs = get_default_ext_attrs(review_list=ipaddrs)
         for _ip in ipaddrs:
             _, prefix_length = _ip["network"].split("/")
+            dns_name = ""
             if _ip["names"]:
-                ip_ext_attrs = get_ext_attr_dict(extattrs=_ip.get("extattrs", {}))
-                new_ip = self.ipaddress(
-                    address=_ip["ip_address"],
-                    prefix=_ip["network"],
-                    prefix_length=prefix_length,
-                    dns_name=_ip["names"][0],
-                    status=self.conn.get_ipaddr_status(_ip),
-                    description=_ip["comment"],
-                    ext_attrs={**default_ext_attrs, **ip_ext_attrs},
-                )
-                self.add(new_ip)
+                dns_name = get_dns_name(possible_fqdn=_ip["names"][0])
+            ip_ext_attrs = get_ext_attr_dict(extattrs=_ip.get("extattrs", {}))
+            new_ip = self.ipaddress(
+                address=_ip["ip_address"],
+                prefix=_ip["network"],
+                prefix_length=prefix_length,
+                dns_name=dns_name,
+                status=self.conn.get_ipaddr_status(_ip),
+                description=_ip["comment"],
+                ext_attrs={**default_ext_attrs, **ip_ext_attrs},
+            )
+            self.add(new_ip)
 
     def load_vlanviews(self):
         """Load InfobloxVLANView DiffSync model."""

--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -119,9 +119,13 @@ class InfobloxAdapter(DiffSync):
     def load(self):
         """Load all models by calling other methods."""
         self.load_prefixes()
+        self.job.log(message=f"Loaded {len(self.dict()['prefix'])} prefixes from Infoblox.")
         self.load_ipaddresses()
+        self.job.log(message=f"Loaded {len(self.dict()['ipaddress'])} IP addresses from Infoblox.")
         self.load_vlanviews()
+        self.job.log(message=f"Loaded {len(self.dict()['vlangroup'])} VLAN views from Infoblox.")
         self.load_vlans()
+        self.job.log(message=f"Loaded {len(self.dict()['vlan'])} VLANs from Infoblox.")
 
     def sync_complete(self, source, diff, flags=DiffSyncFlags.NONE, logger=None):
         """Add tags and custom fields to synced objects."""

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -214,24 +214,22 @@ class NautobotAdapter(NautobotMixin, DiffSync):  # pylint: disable=too-many-inst
     def load_vlans(self):
         """Load VLANs from Nautobot."""
         default_cfs = get_default_custom_fields(cf_contenttype=ContentType.objects.get_for_model(VLAN))
-        for vlan in VLAN.objects.all():
-            # we only care about VLANs associated with a Group to match Infoblox requiring VLANs to belong to a VLANView
-            if getattr(vlan, "group"):
-                if vlan.group.name not in self.vlan_map:
-                    self.vlan_map[vlan.group.name] = {}
-                self.vlan_map[vlan.group.name][vlan.vid] = vlan.id
-                if "ssot-synced-to-infoblox" in vlan.custom_field_data:
-                    vlan.custom_field_data.pop("ssot-synced-to-infoblox")
-                _vlan = self.vlan(
-                    vid=vlan.vid,
-                    name=vlan.name,
-                    description=vlan.description,
-                    vlangroup=vlan.group.name if vlan.group else "",
-                    status=nautobot_vlan_status(vlan.status.name),
-                    ext_attrs={**default_cfs, **vlan.custom_field_data},
-                    pk=vlan.id,
-                )
-                self.add(_vlan)
+        for vlan in VLAN.objects.filter(group__isnull=False):
+            if vlan.group.name not in self.vlan_map:
+                self.vlan_map[vlan.group.name] = {}
+            self.vlan_map[vlan.group.name][vlan.vid] = vlan.id
+            if "ssot-synced-to-infoblox" in vlan.custom_field_data:
+                vlan.custom_field_data.pop("ssot-synced-to-infoblox")
+            _vlan = self.vlan(
+                vid=vlan.vid,
+                name=vlan.name,
+                description=vlan.description,
+                vlangroup=vlan.group.name if vlan.group else "",
+                status=nautobot_vlan_status(vlan.status.name),
+                ext_attrs={**default_cfs, **vlan.custom_field_data},
+                pk=vlan.id,
+            )
+            self.add(_vlan)
 
     def load(self):
         """Load models with data from Nautobot."""

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -194,13 +194,17 @@ class NautobotAdapter(NautobotMixin, DiffSync):
     def load(self):
         """Load models with data from Nautobot."""
         self.load_prefixes()
-        self.job.log(message=f"Loaded {len(self.dict()['prefix'])} prefixes from Nautobot.")
+        if "prefix" in self.dict():
+            self.job.log(message=f"Loaded {len(self.dict()['prefix'])} prefixes from Nautobot.")
         self.load_ipaddresses()
-        self.job.log(message=f"Loaded {len(self.dict()['ipaddress'])} IP addresses from Nautobot.")
+        if "ipaddress" in self.dict():
+            self.job.log(message=f"Loaded {len(self.dict()['ipaddress'])} IP addresses from Nautobot.")
         self.load_vlangroups()
-        self.job.log(message=f"Loaded {len(self.dict()['vlangroup'])} VLAN Groups from Nautobot.")
+        if "vlangroup" in self.dict():
+            self.job.log(message=f"Loaded {len(self.dict()['vlangroup'])} VLAN Groups from Nautobot.")
         self.load_vlans()
-        self.job.log(message=f"Loaded {len(self.dict()['vlan'])} VLANs from Nautobot.")
+        if "vlan" in self.dict():
+            self.job.log(message=f"Loaded {len(self.dict()['vlan'])} VLANs from Nautobot.")
 
 
 class NautobotAggregateAdapter(NautobotMixin, DiffSync):

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -213,6 +213,8 @@ class NautobotAdapter(NautobotMixin, DiffSync):  # pylint: disable=too-many-inst
     def load_vlans(self):
         """Load VLANs from Nautobot."""
         default_cfs = get_default_custom_fields(cf_contenttype=ContentType.objects.get_for_model(VLAN))
+        # To ensure we are only dealing with VLANs imported from Infoblox we need to filter to those with a
+        # VLAN Group assigned to match how Infoblox requires a VLAN View to be associated to VLANs.
         for vlan in VLAN.objects.filter(group__isnull=False):
             if vlan.group.name not in self.vlan_map:
                 self.vlan_map[vlan.group.name] = {}

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -1,12 +1,15 @@
 """Nautobot Adapter for Infoblox integration with SSoT plugin."""
+from collections import defaultdict
 import datetime
 from itertools import chain
 from diffsync import DiffSync
 from diffsync.exceptions import ObjectAlreadyExists, ObjectNotFound
 from django.contrib.contenttypes.models import ContentType
+from nautobot.dcim.models import Site
 from nautobot.extras.choices import CustomFieldTypeChoices
-from nautobot.extras.models import Tag, CustomField
-from nautobot.ipam.models import Aggregate, IPAddress, Prefix, VLAN, VLANGroup
+from nautobot.extras.models import Relationship, Status, Tag, CustomField
+from nautobot.ipam.models import Aggregate, IPAddress, Prefix, Role, VLAN, VLANGroup
+from nautobot.tenancy.models import Tenant
 from nautobot_ssot_infoblox.diffsync.models import (
     NautobotAggregate,
     NautobotNetwork,
@@ -77,7 +80,7 @@ class NautobotMixin:
             _tag_object(Prefix.objects.get(pk=model_instance.pk))
 
 
-class NautobotAdapter(NautobotMixin, DiffSync):
+class NautobotAdapter(NautobotMixin, DiffSync):  # pylint: disable=too-many-instance-attributes
     """DiffSync adapter using ORM to communicate to Nautobot."""
 
     prefix = NautobotNetwork
@@ -86,6 +89,17 @@ class NautobotAdapter(NautobotMixin, DiffSync):
     vlan = NautobotVlan
 
     top_level = ["vlangroup", "vlan", "prefix", "ipaddress"]
+
+    status_map = {}
+    site_map = {}
+    relationship_map = {}
+    tenant_map = {}
+    vrf_map = {}
+    prefix_map = {}
+    role_map = {}
+    ipaddr_map = {}
+    vlan_map = {}
+    vlangroup_map = {}
 
     def __init__(self, *args, job=None, sync=None, **kwargs):
         """Initialize Nautobot.
@@ -97,12 +111,33 @@ class NautobotAdapter(NautobotMixin, DiffSync):
         super().__init__(*args, **kwargs)
         self.job = job
         self.sync = sync
+        self.objects_to_create = defaultdict(list)
+
+    def sync_complete(self, source: DiffSync, *args, **kwargs):
+        """Process object creations/updates using bulk operations.
+
+        Args:
+            source (DiffSync): Source DiffSync adapter data.
+        """
+        if len(self.objects_to_create["vlangroups"]) > 0:
+            self.job.log_info(message="Performing bulk create of VLAN Groups in Nautobot")
+            VLANGroup.objects.bulk_create(self.objects_to_create["vlangroups"], batch_size=250)
+        if len(self.objects_to_create["vlans"]) > 0:
+            self.job.log_info(message="Performing bulk create of VLANs in Nautobot.")
+            VLAN.objects.bulk_create(self.objects_to_create["vlans"], batch_size=500)
+        if len(self.objects_to_create["prefixes"]) > 0:
+            self.job.log_info(message="Performing bulk create of Prefixes in Nautobot")
+            Prefix.objects.bulk_create(self.objects_to_create["prefixes"], batch_size=500)
+        if len(self.objects_to_create["ipaddrs"]) > 0:
+            self.job.log_info(message="Performing bulk create of IP Addresses in Nautobot")
+            IPAddress.objects.bulk_create(self.objects_to_create["ipaddrs"], batch_size=1000)
 
     def load_prefixes(self):
         """Load Prefixes from Nautobot."""
         all_prefixes = list(chain(Prefix.objects.all(), Aggregate.objects.all()))
         default_cfs = get_default_custom_fields(cf_contenttype=ContentType.objects.get_for_model(Prefix))
         for prefix in all_prefixes:
+            self.prefix_map[str(prefix.prefix)] = prefix.id
             if "ssot-synced-to-infoblox" in prefix.custom_field_data:
                 prefix.custom_field_data.pop("ssot-synced-to-infoblox")
             current_vlans = get_prefix_vlans(prefix=prefix)
@@ -123,6 +158,7 @@ class NautobotAdapter(NautobotMixin, DiffSync):
         """Load IP Addresses from Nautobot."""
         default_cfs = get_default_custom_fields(cf_contenttype=ContentType.objects.get_for_model(IPAddress))
         for ipaddr in IPAddress.objects.all():
+            self.ipaddr_map[str(ipaddr.address)] = ipaddr.id
             addr = ipaddr.host
             # the last Prefix is the most specific and is assumed the one the IP address resides in
             prefix = Prefix.objects.net_contains(addr).last()
@@ -164,6 +200,7 @@ class NautobotAdapter(NautobotMixin, DiffSync):
         """Load VLAN Groups from Nautobot."""
         default_cfs = get_default_custom_fields(cf_contenttype=ContentType.objects.get_for_model(VLANGroup))
         for grp in VLANGroup.objects.all():
+            self.vlangroup_map[grp.name] = grp.id
             if "ssot-synced-to-infoblox" in grp.custom_field_data:
                 grp.custom_field_data.pop("ssot-synced-to-infoblox")
             _vg = self.vlangroup(
@@ -178,6 +215,9 @@ class NautobotAdapter(NautobotMixin, DiffSync):
         """Load VLANs from Nautobot."""
         default_cfs = get_default_custom_fields(cf_contenttype=ContentType.objects.get_for_model(VLAN))
         for vlan in VLAN.objects.all():
+            if vlan.group.name not in self.vlan_map:
+                self.vlan_map[vlan.group.name] = {}
+            self.vlan_map[vlan.group.name][vlan.vid] = vlan.id
             if "ssot-synced-to-infoblox" in vlan.custom_field_data:
                 vlan.custom_field_data.pop("ssot-synced-to-infoblox")
             _vlan = self.vlan(
@@ -193,6 +233,11 @@ class NautobotAdapter(NautobotMixin, DiffSync):
 
     def load(self):
         """Load models with data from Nautobot."""
+        self.relationship_map = {r.name: r.id for r in Relationship.objects.only("id", "name")}
+        self.status_map = {s.slug: s.id for s in Status.objects.only("id", "slug")}
+        self.site_map = {s.name: s.id for s in Site.objects.only("id", "name")}
+        self.tenant_map = {t.name: t.id for t in Tenant.objects.only("id", "name")}
+        self.role_map = {r.name: r.id for r in Role.objects.only("id", "name")}
         self.load_prefixes()
         if "prefix" in self.dict():
             self.job.log(message=f"Loaded {len(self.dict()['prefix'])} prefixes from Nautobot.")

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -194,9 +194,13 @@ class NautobotAdapter(NautobotMixin, DiffSync):
     def load(self):
         """Load models with data from Nautobot."""
         self.load_prefixes()
+        self.job.log(message=f"Loaded {len(self.dict()['prefix'])} prefixes from Nautobot.")
         self.load_ipaddresses()
+        self.job.log(message=f"Loaded {len(self.dict()['ipaddress'])} IP addresses from Nautobot.")
         self.load_vlangroups()
+        self.job.log(message=f"Loaded {len(self.dict()['vlangroup'])} VLAN Groups from Nautobot.")
         self.load_vlans()
+        self.job.log(message=f"Loaded {len(self.dict()['vlan'])} VLANs from Nautobot.")
 
 
 class NautobotAggregateAdapter(NautobotMixin, DiffSync):

--- a/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/nautobot.py
@@ -178,23 +178,22 @@ class NautobotAdapter(NautobotMixin, DiffSync):  # pylint: disable=too-many-inst
                 )
                 continue
 
-            if ipaddr.dns_name:
-                if "ssot-synced-to-infoblox" in ipaddr.custom_field_data:
-                    ipaddr.custom_field_data.pop("ssot-synced-to-infoblox")
-                _ip = self.ipaddress(
-                    address=addr,
-                    prefix=str(prefix),
-                    status=ipaddr.status.name if ipaddr.status else None,
-                    prefix_length=prefix.prefix_length if prefix else ipaddr.prefix_length,
-                    dns_name=ipaddr.dns_name,
-                    description=ipaddr.description,
-                    ext_attrs={**default_cfs, **ipaddr.custom_field_data},
-                    pk=ipaddr.id,
-                )
-                try:
-                    self.add(_ip)
-                except ObjectAlreadyExists:
-                    self.job.log_warning(ipaddr, message=f"Duplicate IP Address detected: {addr}.")
+            if "ssot-synced-to-infoblox" in ipaddr.custom_field_data:
+                ipaddr.custom_field_data.pop("ssot-synced-to-infoblox")
+            _ip = self.ipaddress(
+                address=addr,
+                prefix=str(prefix),
+                status=ipaddr.status.name if ipaddr.status else None,
+                prefix_length=prefix.prefix_length if prefix else ipaddr.prefix_length,
+                dns_name=ipaddr.dns_name,
+                description=ipaddr.description,
+                ext_attrs={**default_cfs, **ipaddr.custom_field_data},
+                pk=ipaddr.id,
+            )
+            try:
+                self.add(_ip)
+            except ObjectAlreadyExists:
+                self.job.log_warning(ipaddr, message=f"Duplicate IP Address detected: {addr}.")
 
     def load_vlangroups(self):
         """Load VLAN Groups from Nautobot."""

--- a/nautobot_ssot_infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/models/nautobot.py
@@ -218,9 +218,7 @@ class NautobotIPAddress(IPAddress):
             _ipaddr.validated_save()
             return super().update(attrs)
         except ValidationError as err:
-            self.diffsync.job.log_warning(
-                message=f"Error with updating IP Address {self.address}. {err}"
-            )
+            self.diffsync.job.log_warning(message=f"Error with updating IP Address {self.address}. {err}")
             return None
 
     # def delete(self):

--- a/nautobot_ssot_infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/models/nautobot.py
@@ -100,7 +100,7 @@ class NautobotNetwork(Network):
                             source_type=ContentType.objects.get_for_model(OrmPrefix),
                             source_id=_prefix.id,
                             destination_type=ContentType.objects.get_for_model(OrmVlan),
-                            destination_id=found_vlan.id,
+                            destination_id=found_vlan,
                         )
                     index += 1
                 except KeyError as err:
@@ -185,7 +185,7 @@ class NautobotIPAddress(IPAddress):
         """Create IPAddress object in Nautobot."""
         _pf = ipaddress.ip_network(ids["prefix"])
         try:
-            status = diffsync.status_map[attrs["status"]]
+            status = diffsync.status_map[slugify(attrs["status"])]
         except KeyError:
             status = diffsync.status_map["active"]
         _ip = OrmIPAddress(
@@ -213,7 +213,7 @@ class NautobotIPAddress(IPAddress):
         _ipaddr = OrmIPAddress.objects.get(id=self.pk)
         if attrs.get("status"):
             try:
-                status = self.diffsync.status_map[attrs["status"]]
+                status = self.diffsync.status_map[slugify(attrs["status"])]
             except KeyError:
                 status = self.diffsync.status_map["active"]
             _ipaddr.status_id = status

--- a/nautobot_ssot_infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/models/nautobot.py
@@ -279,8 +279,8 @@ class NautobotVlan(Vlan):
         _vlan = OrmVlan(
             vid=ids["vid"],
             name=ids["name"],
-            status=diffsync.status_map[cls.get_vlan_status(attrs["status"])],
-            group=OrmVlanGroup.objects.get(name=ids["vlangroup"]) if ids["vlangroup"] else None,
+            status_id=diffsync.status_map[cls.get_vlan_status(attrs["status"])],
+            group_id=diffsync.vlangroup_map[ids["vlangroup"]],
             description=attrs["description"],
         )
         if "ext_attrs" in attrs:
@@ -317,7 +317,7 @@ class NautobotVlan(Vlan):
         """Update VLAN object in Nautobot."""
         _vlan = OrmVlan.objects.get(id=self.pk)
         if attrs.get("status"):
-            _vlan.status = self.diffsync.status_map[self.get_vlan_status(attrs["status"])]
+            _vlan.status_id = self.diffsync.status_map[self.get_vlan_status(attrs["status"])]
         if attrs.get("description"):
             _vlan.description = attrs["description"]
         if "ext_attrs" in attrs:

--- a/nautobot_ssot_infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot_infoblox/diffsync/models/nautobot.py
@@ -130,7 +130,7 @@ class NautobotNetwork(Network):
             _pf.status = OrmStatus.objects.get(slug=attrs["status"])
         if "ext_attrs" in attrs:
             process_ext_attrs(diffsync=self.diffsync, obj=_pf, extattrs=attrs["ext_attrs"])
-        if "vlans" in attrs:
+        if "vlans" in attrs:  # pylint: disable=too-many-nested-blocks
             current_vlans = get_prefix_vlans(prefix=_pf)
             if len(current_vlans) < len(attrs["vlans"]):
                 for _, item in attrs["vlans"].items():

--- a/nautobot_ssot_infoblox/tests/fixtures/get_all_ipv4address_networks.json
+++ b/nautobot_ssot_infoblox/tests/fixtures/get_all_ipv4address_networks.json
@@ -7,7 +7,7 @@
 			"lease_state": "FREE",
 			"mac_address": "55:55:55:55:55:55",
 			"names": [],
-			"network": "10.220.0.0/22",
+			"network": "10.220.0.0/31",
 			"network_view": "default",
 			"objects": [
 				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.220.0.100/default"
@@ -30,7 +30,7 @@
 			"names": [
 				"testdevice1.test"
 			],
-			"network": "10.220.0.0/22",
+			"network": "10.220.0.0/31",
 			"network_view": "default",
 			"objects": [
 				"record:host/ZG5zLmhvc3QkLl9kZWZhdWx0LnRlc3QudGVzdGRldmljZTE:testdevice1.test/default"

--- a/nautobot_ssot_infoblox/tests/fixtures/get_all_ipv4address_networks_bulk.json
+++ b/nautobot_ssot_infoblox/tests/fixtures/get_all_ipv4address_networks_bulk.json
@@ -1,0 +1,25 @@
+[
+	[
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:192.168.0.1",
+			"ip_address": "192.168.0.1",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "aa:bb:cc:dd:ee:ff",
+			"names": [],
+			"network": "192.168.0.0/23",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:192.168.0.1/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		}
+	]
+]

--- a/nautobot_ssot_infoblox/tests/fixtures/get_all_ipv4address_networks_large.json
+++ b/nautobot_ssot_infoblox/tests/fixtures/get_all_ipv4address_networks_large.json
@@ -1,0 +1,21466 @@
+[
+	[
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.215",
+			"ip_address": "10.0.1.215",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.215/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.207",
+			"ip_address": "10.0.2.207",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.207/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.4",
+			"ip_address": "10.0.0.4",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.4/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.211",
+			"ip_address": "10.0.1.211",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.211/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.242",
+			"ip_address": "10.0.0.242",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.242/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.20",
+			"ip_address": "10.0.2.20",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.20/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.98",
+			"ip_address": "10.0.2.98",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.98/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.232",
+			"ip_address": "10.0.1.232",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.232/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.138",
+			"ip_address": "10.0.3.138",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.138/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.230",
+			"ip_address": "10.0.2.230",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.230/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.137",
+			"ip_address": "10.0.0.137",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.137/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.220",
+			"ip_address": "10.0.1.220",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.220/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.255",
+			"ip_address": "10.0.2.255",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.255/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.38",
+			"ip_address": "10.0.2.38",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.38/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.100",
+			"ip_address": "10.0.0.100",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.100/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.187",
+			"ip_address": "10.0.0.187",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.187/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.95",
+			"ip_address": "10.0.3.95",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.95/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.210",
+			"ip_address": "10.0.2.210",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.210/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.18",
+			"ip_address": "10.0.2.18",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.18/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.245",
+			"ip_address": "10.0.1.245",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.245/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.212",
+			"ip_address": "10.0.0.212",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.212/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.169",
+			"ip_address": "10.0.1.169",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.169/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.90",
+			"ip_address": "10.0.2.90",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.90/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.195",
+			"ip_address": "10.0.0.195",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.195/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.243",
+			"ip_address": "10.0.1.243",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.243/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.103",
+			"ip_address": "10.0.3.103",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.103/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.225",
+			"ip_address": "10.0.2.225",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.225/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.224",
+			"ip_address": "10.0.0.224",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.224/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.110",
+			"ip_address": "10.0.2.110",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.110/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.7",
+			"ip_address": "10.0.0.7",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.7/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.20",
+			"ip_address": "10.0.1.20",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.20/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.131",
+			"ip_address": "10.0.1.131",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.131/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.185",
+			"ip_address": "10.0.1.185",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.185/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.29",
+			"ip_address": "10.0.0.29",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.29/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.17",
+			"ip_address": "10.0.3.17",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.17/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.177",
+			"ip_address": "10.0.2.177",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.177/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.152",
+			"ip_address": "10.0.1.152",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.152/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.79",
+			"ip_address": "10.0.2.79",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.79/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.249",
+			"ip_address": "10.0.3.249",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.249/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.150",
+			"ip_address": "10.0.0.150",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.150/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.246",
+			"ip_address": "10.0.0.246",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.246/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.52",
+			"ip_address": "10.0.2.52",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.52/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.170",
+			"ip_address": "10.0.1.170",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.170/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.249",
+			"ip_address": "10.0.0.249",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.249/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.183",
+			"ip_address": "10.0.0.183",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.183/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.234",
+			"ip_address": "10.0.0.234",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.234/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.29",
+			"ip_address": "10.0.2.29",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.29/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.208",
+			"ip_address": "10.0.2.208",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.208/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.235",
+			"ip_address": "10.0.3.235",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.235/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.3",
+			"ip_address": "10.0.0.3",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.3/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.37",
+			"ip_address": "10.0.1.37",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.37/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.180",
+			"ip_address": "10.0.1.180",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.180/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.172",
+			"ip_address": "10.0.2.172",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.172/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.233",
+			"ip_address": "10.0.3.233",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.233/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.152",
+			"ip_address": "10.0.0.152",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.152/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.186",
+			"ip_address": "10.0.2.186",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.186/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.17",
+			"ip_address": "10.0.1.17",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.17/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.138",
+			"ip_address": "10.0.0.138",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.138/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.121",
+			"ip_address": "10.0.1.121",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.121/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.134",
+			"ip_address": "10.0.0.134",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.134/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.137",
+			"ip_address": "10.0.3.137",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.137/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.77",
+			"ip_address": "10.0.1.77",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.77/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.62",
+			"ip_address": "10.0.3.62",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.62/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.153",
+			"ip_address": "10.0.2.153",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.153/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.156",
+			"ip_address": "10.0.0.156",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.156/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.137",
+			"ip_address": "10.0.2.137",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.137/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.176",
+			"ip_address": "10.0.0.176",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.176/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.14",
+			"ip_address": "10.0.0.14",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.14/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.50",
+			"ip_address": "10.0.0.50",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.50/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.157",
+			"ip_address": "10.0.0.157",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.157/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.239",
+			"ip_address": "10.0.0.239",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.239/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.102",
+			"ip_address": "10.0.2.102",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.102/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.152",
+			"ip_address": "10.0.2.152",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.152/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.238",
+			"ip_address": "10.0.2.238",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.238/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.59",
+			"ip_address": "10.0.0.59",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.59/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.120",
+			"ip_address": "10.0.1.120",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.120/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.85",
+			"ip_address": "10.0.1.85",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.85/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.37",
+			"ip_address": "10.0.2.37",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.37/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.248",
+			"ip_address": "10.0.2.248",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.248/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.252",
+			"ip_address": "10.0.2.252",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.252/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.53",
+			"ip_address": "10.0.2.53",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.53/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.57",
+			"ip_address": "10.0.0.57",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.57/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.188",
+			"ip_address": "10.0.0.188",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.188/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.70",
+			"ip_address": "10.0.3.70",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.70/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.107",
+			"ip_address": "10.0.1.107",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.107/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.154",
+			"ip_address": "10.0.0.154",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.154/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.131",
+			"ip_address": "10.0.2.131",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.131/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.87",
+			"ip_address": "10.0.0.87",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.87/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.81",
+			"ip_address": "10.0.1.81",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.81/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.73",
+			"ip_address": "10.0.0.73",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.73/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.45",
+			"ip_address": "10.0.3.45",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.45/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.52",
+			"ip_address": "10.0.3.52",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.52/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.171",
+			"ip_address": "10.0.2.171",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.171/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.132",
+			"ip_address": "10.0.3.132",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.132/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.146",
+			"ip_address": "10.0.0.146",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.146/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.245",
+			"ip_address": "10.0.3.245",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.245/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.175",
+			"ip_address": "10.0.1.175",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.175/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.178",
+			"ip_address": "10.0.0.178",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.178/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.18",
+			"ip_address": "10.0.3.18",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.18/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.244",
+			"ip_address": "10.0.1.244",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.244/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.167",
+			"ip_address": "10.0.3.167",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.167/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.142",
+			"ip_address": "10.0.1.142",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.142/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.31",
+			"ip_address": "10.0.2.31",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.31/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.21",
+			"ip_address": "10.0.3.21",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.21/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.44",
+			"ip_address": "10.0.0.44",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.44/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.239",
+			"ip_address": "10.0.2.239",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.239/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.68",
+			"ip_address": "10.0.0.68",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.68/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.148",
+			"ip_address": "10.0.3.148",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.148/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.143",
+			"ip_address": "10.0.0.143",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.143/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.56",
+			"ip_address": "10.0.0.56",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.56/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.89",
+			"ip_address": "10.0.1.89",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.89/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.221",
+			"ip_address": "10.0.1.221",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.221/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.42",
+			"ip_address": "10.0.3.42",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.42/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.88",
+			"ip_address": "10.0.1.88",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.88/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.233",
+			"ip_address": "10.0.2.233",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.233/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.19",
+			"ip_address": "10.0.0.19",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.19/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.66",
+			"ip_address": "10.0.2.66",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.66/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.245",
+			"ip_address": "10.0.0.245",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.245/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.233",
+			"ip_address": "10.0.1.233",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.233/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.140",
+			"ip_address": "10.0.2.140",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.140/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.131",
+			"ip_address": "10.0.3.131",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.131/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.172",
+			"ip_address": "10.0.3.172",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.172/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.6",
+			"ip_address": "10.0.1.6",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.6/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.219",
+			"ip_address": "10.0.2.219",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.219/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.106",
+			"ip_address": "10.0.1.106",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.106/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.108",
+			"ip_address": "10.0.1.108",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.108/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.157",
+			"ip_address": "10.0.1.157",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.157/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.113",
+			"ip_address": "10.0.1.113",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.113/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.202",
+			"ip_address": "10.0.0.202",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.202/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.7",
+			"ip_address": "10.0.1.7",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.7/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.64",
+			"ip_address": "10.0.0.64",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.64/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.87",
+			"ip_address": "10.0.2.87",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.87/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.184",
+			"ip_address": "10.0.2.184",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.184/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.209",
+			"ip_address": "10.0.0.209",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.209/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.188",
+			"ip_address": "10.0.2.188",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.188/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.75",
+			"ip_address": "10.0.2.75",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.75/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.53",
+			"ip_address": "10.0.3.53",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.53/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.74",
+			"ip_address": "10.0.3.74",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.74/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.107",
+			"ip_address": "10.0.3.107",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.107/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.146",
+			"ip_address": "10.0.3.146",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.146/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.253",
+			"ip_address": "10.0.1.253",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.253/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.144",
+			"ip_address": "10.0.3.144",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.144/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.86",
+			"ip_address": "10.0.1.86",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.86/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.221",
+			"ip_address": "10.0.0.221",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.221/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.215",
+			"ip_address": "10.0.2.215",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.215/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.142",
+			"ip_address": "10.0.2.142",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.142/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.205",
+			"ip_address": "10.0.0.205",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.205/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.201",
+			"ip_address": "10.0.1.201",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.201/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.39",
+			"ip_address": "10.0.1.39",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.39/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.203",
+			"ip_address": "10.0.3.203",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.203/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.90",
+			"ip_address": "10.0.0.90",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.90/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.8",
+			"ip_address": "10.0.2.8",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.8/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.97",
+			"ip_address": "10.0.3.97",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.97/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.253",
+			"ip_address": "10.0.0.253",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.253/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.186",
+			"ip_address": "10.0.1.186",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.186/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.2",
+			"ip_address": "10.0.2.2",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.2/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.5",
+			"ip_address": "10.0.1.5",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.5/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.34",
+			"ip_address": "10.0.3.34",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.34/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.100",
+			"ip_address": "10.0.2.100",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.100/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.73",
+			"ip_address": "10.0.1.73",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.73/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.33",
+			"ip_address": "10.0.2.33",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.33/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.39",
+			"ip_address": "10.0.2.39",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.39/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.230",
+			"ip_address": "10.0.0.230",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.230/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.226",
+			"ip_address": "10.0.1.226",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.226/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.130",
+			"ip_address": "10.0.0.130",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.130/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.41",
+			"ip_address": "10.0.2.41",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.41/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.224",
+			"ip_address": "10.0.3.224",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.224/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.238",
+			"ip_address": "10.0.3.238",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.238/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.52",
+			"ip_address": "10.0.1.52",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.52/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.92",
+			"ip_address": "10.0.1.92",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.92/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.61",
+			"ip_address": "10.0.0.61",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.61/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.21",
+			"ip_address": "10.0.2.21",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.21/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.28",
+			"ip_address": "10.0.0.28",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.28/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.128",
+			"ip_address": "10.0.0.128",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.128/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.105",
+			"ip_address": "10.0.0.105",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.105/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.155",
+			"ip_address": "10.0.0.155",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.155/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.34",
+			"ip_address": "10.0.1.34",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.34/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.251",
+			"ip_address": "10.0.0.251",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.251/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.80",
+			"ip_address": "10.0.3.80",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.80/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.159",
+			"ip_address": "10.0.2.159",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.159/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.174",
+			"ip_address": "10.0.2.174",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.174/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.161",
+			"ip_address": "10.0.0.161",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.161/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.141",
+			"ip_address": "10.0.2.141",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.141/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.139",
+			"ip_address": "10.0.0.139",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.139/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.220",
+			"ip_address": "10.0.3.220",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.220/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.41",
+			"ip_address": "10.0.3.41",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.41/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.166",
+			"ip_address": "10.0.0.166",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.166/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.228",
+			"ip_address": "10.0.1.228",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.228/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.174",
+			"ip_address": "10.0.3.174",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.174/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.10",
+			"ip_address": "10.0.0.10",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.10/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.142",
+			"ip_address": "10.0.0.142",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.142/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.182",
+			"ip_address": "10.0.0.182",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.182/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.160",
+			"ip_address": "10.0.1.160",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.160/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.175",
+			"ip_address": "10.0.2.175",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.175/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.24",
+			"ip_address": "10.0.1.24",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.24/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.141",
+			"ip_address": "10.0.1.141",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.141/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.49",
+			"ip_address": "10.0.3.49",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.49/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.215",
+			"ip_address": "10.0.0.215",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.215/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.240",
+			"ip_address": "10.0.1.240",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.240/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.170",
+			"ip_address": "10.0.2.170",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.170/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.144",
+			"ip_address": "10.0.0.144",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.144/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.228",
+			"ip_address": "10.0.2.228",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.228/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.250",
+			"ip_address": "10.0.0.250",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.250/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.21",
+			"ip_address": "10.0.0.21",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.21/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.89",
+			"ip_address": "10.0.0.89",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.89/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.93",
+			"ip_address": "10.0.3.93",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.93/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.101",
+			"ip_address": "10.0.2.101",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.101/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.103",
+			"ip_address": "10.0.1.103",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.103/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.38",
+			"ip_address": "10.0.1.38",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.38/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.151",
+			"ip_address": "10.0.1.151",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.151/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.28",
+			"ip_address": "10.0.2.28",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.28/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.117",
+			"ip_address": "10.0.2.117",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.117/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.211",
+			"ip_address": "10.0.2.211",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.211/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.67",
+			"ip_address": "10.0.3.67",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.67/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.161",
+			"ip_address": "10.0.3.161",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.161/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.165",
+			"ip_address": "10.0.0.165",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.165/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.65",
+			"ip_address": "10.0.3.65",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.65/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.228",
+			"ip_address": "10.0.3.228",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.228/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.218",
+			"ip_address": "10.0.1.218",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.218/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.16",
+			"ip_address": "10.0.2.16",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.16/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.148",
+			"ip_address": "10.0.0.148",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.148/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.94",
+			"ip_address": "10.0.2.94",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.94/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.37",
+			"ip_address": "10.0.3.37",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.37/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.181",
+			"ip_address": "10.0.0.181",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.181/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.15",
+			"ip_address": "10.0.1.15",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.15/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.83",
+			"ip_address": "10.0.1.83",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.83/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.236",
+			"ip_address": "10.0.0.236",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.236/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.223",
+			"ip_address": "10.0.0.223",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.223/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.89",
+			"ip_address": "10.0.2.89",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.89/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.12",
+			"ip_address": "10.0.1.12",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.12/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.63",
+			"ip_address": "10.0.0.63",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.63/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.11",
+			"ip_address": "10.0.1.11",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.11/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.118",
+			"ip_address": "10.0.2.118",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.118/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.112",
+			"ip_address": "10.0.2.112",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.112/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.39",
+			"ip_address": "10.0.3.39",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.39/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.254",
+			"ip_address": "10.0.0.254",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.254/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.2",
+			"ip_address": "10.0.0.2",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.2/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.35",
+			"ip_address": "10.0.0.35",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.35/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.181",
+			"ip_address": "10.0.3.181",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.181/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.131",
+			"ip_address": "10.0.0.131",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.131/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.171",
+			"ip_address": "10.0.3.171",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.171/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.104",
+			"ip_address": "10.0.0.104",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.104/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.67",
+			"ip_address": "10.0.2.67",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.67/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.42",
+			"ip_address": "10.0.2.42",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.42/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.116",
+			"ip_address": "10.0.3.116",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.116/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.72",
+			"ip_address": "10.0.3.72",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.72/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.223",
+			"ip_address": "10.0.1.223",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.223/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.22",
+			"ip_address": "10.0.0.22",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.22/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.59",
+			"ip_address": "10.0.3.59",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.59/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.252",
+			"ip_address": "10.0.1.252",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.252/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.124",
+			"ip_address": "10.0.3.124",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.124/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.216",
+			"ip_address": "10.0.2.216",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.216/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.207",
+			"ip_address": "10.0.1.207",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.207/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.80",
+			"ip_address": "10.0.0.80",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.80/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.206",
+			"ip_address": "10.0.1.206",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.206/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.73",
+			"ip_address": "10.0.2.73",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.73/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.159",
+			"ip_address": "10.0.0.159",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.159/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.119",
+			"ip_address": "10.0.3.119",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.119/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.96",
+			"ip_address": "10.0.2.96",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.96/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.215",
+			"ip_address": "10.0.3.215",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.215/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.179",
+			"ip_address": "10.0.1.179",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.179/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.1",
+			"ip_address": "10.0.2.1",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.1/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.123",
+			"ip_address": "10.0.2.123",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.123/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.59",
+			"ip_address": "10.0.1.59",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.59/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.136",
+			"ip_address": "10.0.2.136",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.136/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.143",
+			"ip_address": "10.0.2.143",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.143/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.5",
+			"ip_address": "10.0.2.5",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.5/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.145",
+			"ip_address": "10.0.3.145",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.145/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.186",
+			"ip_address": "10.0.0.186",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.186/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.132",
+			"ip_address": "10.0.0.132",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.132/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.26",
+			"ip_address": "10.0.2.26",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.26/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.154",
+			"ip_address": "10.0.3.154",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.154/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.201",
+			"ip_address": "10.0.3.201",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.201/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.123",
+			"ip_address": "10.0.1.123",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.123/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.26",
+			"ip_address": "10.0.1.26",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.26/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.196",
+			"ip_address": "10.0.1.196",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.196/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.244",
+			"ip_address": "10.0.0.244",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.244/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.177",
+			"ip_address": "10.0.1.177",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.177/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.123",
+			"ip_address": "10.0.0.123",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.123/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.46",
+			"ip_address": "10.0.2.46",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.46/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.147",
+			"ip_address": "10.0.1.147",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.147/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.243",
+			"ip_address": "10.0.2.243",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.243/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.114",
+			"ip_address": "10.0.1.114",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.114/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.222",
+			"ip_address": "10.0.2.222",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.222/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.185",
+			"ip_address": "10.0.3.185",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.185/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.33",
+			"ip_address": "10.0.3.33",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.33/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.48",
+			"ip_address": "10.0.0.48",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.48/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.23",
+			"ip_address": "10.0.2.23",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.23/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.226",
+			"ip_address": "10.0.3.226",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.226/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.248",
+			"ip_address": "10.0.0.248",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.248/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.175",
+			"ip_address": "10.0.0.175",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.175/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.212",
+			"ip_address": "10.0.3.212",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.212/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.30",
+			"ip_address": "10.0.3.30",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.30/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.103",
+			"ip_address": "10.0.0.103",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.103/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.159",
+			"ip_address": "10.0.3.159",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.159/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.189",
+			"ip_address": "10.0.3.189",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.189/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.88",
+			"ip_address": "10.0.0.88",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.88/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.19",
+			"ip_address": "10.0.2.19",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.19/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.184",
+			"ip_address": "10.0.3.184",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.184/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.130",
+			"ip_address": "10.0.3.130",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.130/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.183",
+			"ip_address": "10.0.3.183",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.183/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.72",
+			"ip_address": "10.0.2.72",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.72/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.247",
+			"ip_address": "10.0.2.247",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.247/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.240",
+			"ip_address": "10.0.0.240",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.240/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.79",
+			"ip_address": "10.0.0.79",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.79/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.168",
+			"ip_address": "10.0.0.168",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.168/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.171",
+			"ip_address": "10.0.0.171",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.171/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.190",
+			"ip_address": "10.0.3.190",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.190/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.241",
+			"ip_address": "10.0.1.241",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.241/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.254",
+			"ip_address": "10.0.3.254",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.254/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.79",
+			"ip_address": "10.0.1.79",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.79/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.0",
+			"ip_address": "10.0.2.0",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.0/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.189",
+			"ip_address": "10.0.0.189",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.189/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.102",
+			"ip_address": "10.0.1.102",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.102/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.246",
+			"ip_address": "10.0.2.246",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.246/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.196",
+			"ip_address": "10.0.0.196",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.196/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.111",
+			"ip_address": "10.0.3.111",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.111/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.250",
+			"ip_address": "10.0.1.250",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.250/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.58",
+			"ip_address": "10.0.3.58",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.58/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.162",
+			"ip_address": "10.0.0.162",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.162/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.35",
+			"ip_address": "10.0.1.35",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.35/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.118",
+			"ip_address": "10.0.1.118",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.118/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.83",
+			"ip_address": "10.0.0.83",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.83/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.24",
+			"ip_address": "10.0.2.24",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.24/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.219",
+			"ip_address": "10.0.3.219",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.219/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.255",
+			"ip_address": "10.0.0.255",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.255/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.164",
+			"ip_address": "10.0.0.164",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.164/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.199",
+			"ip_address": "10.0.1.199",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.199/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.35",
+			"ip_address": "10.0.2.35",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.35/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.109",
+			"ip_address": "10.0.3.109",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.109/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.182",
+			"ip_address": "10.0.2.182",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.182/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.112",
+			"ip_address": "10.0.3.112",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.112/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.9",
+			"ip_address": "10.0.1.9",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.9/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.249",
+			"ip_address": "10.0.1.249",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.249/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.199",
+			"ip_address": "10.0.2.199",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.199/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.173",
+			"ip_address": "10.0.1.173",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.173/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.0",
+			"ip_address": "10.0.0.0",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.0/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.45",
+			"ip_address": "10.0.2.45",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.45/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.74",
+			"ip_address": "10.0.2.74",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.74/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.22",
+			"ip_address": "10.0.3.22",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.22/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.63",
+			"ip_address": "10.0.1.63",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.63/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.175",
+			"ip_address": "10.0.3.175",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.175/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.161",
+			"ip_address": "10.0.1.161",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.161/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.91",
+			"ip_address": "10.0.3.91",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.91/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.12",
+			"ip_address": "10.0.3.12",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.12/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.246",
+			"ip_address": "10.0.1.246",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.246/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.115",
+			"ip_address": "10.0.1.115",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.115/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.13",
+			"ip_address": "10.0.2.13",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.13/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.179",
+			"ip_address": "10.0.0.179",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.179/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.206",
+			"ip_address": "10.0.2.206",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.206/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.77",
+			"ip_address": "10.0.0.77",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.77/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.41",
+			"ip_address": "10.0.1.41",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.41/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.187",
+			"ip_address": "10.0.1.187",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.187/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.192",
+			"ip_address": "10.0.3.192",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.192/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.160",
+			"ip_address": "10.0.2.160",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.160/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.207",
+			"ip_address": "10.0.0.207",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.207/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.106",
+			"ip_address": "10.0.3.106",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.106/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.49",
+			"ip_address": "10.0.1.49",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.49/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.222",
+			"ip_address": "10.0.1.222",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.222/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.82",
+			"ip_address": "10.0.3.82",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.82/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.187",
+			"ip_address": "10.0.3.187",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.187/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.79",
+			"ip_address": "10.0.3.79",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.79/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.200",
+			"ip_address": "10.0.3.200",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.200/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.244",
+			"ip_address": "10.0.3.244",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.244/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.119",
+			"ip_address": "10.0.1.119",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.119/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.254",
+			"ip_address": "10.0.2.254",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.254/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.196",
+			"ip_address": "10.0.3.196",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.196/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.168",
+			"ip_address": "10.0.3.168",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.168/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.88",
+			"ip_address": "10.0.3.88",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.88/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.95",
+			"ip_address": "10.0.0.95",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.95/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.239",
+			"ip_address": "10.0.1.239",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.239/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.8",
+			"ip_address": "10.0.1.8",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.8/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.101",
+			"ip_address": "10.0.0.101",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.101/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.174",
+			"ip_address": "10.0.1.174",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.174/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.165",
+			"ip_address": "10.0.2.165",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.165/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.221",
+			"ip_address": "10.0.2.221",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.221/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.186",
+			"ip_address": "10.0.3.186",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.186/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.120",
+			"ip_address": "10.0.0.120",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.120/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.44",
+			"ip_address": "10.0.2.44",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.44/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.252",
+			"ip_address": "10.0.0.252",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.252/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.166",
+			"ip_address": "10.0.3.166",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.166/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.30",
+			"ip_address": "10.0.0.30",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.30/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.4",
+			"ip_address": "10.0.2.4",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.4/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.3",
+			"ip_address": "10.0.1.3",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.3/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.132",
+			"ip_address": "10.0.1.132",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.132/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.224",
+			"ip_address": "10.0.2.224",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.224/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.43",
+			"ip_address": "10.0.3.43",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.43/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.231",
+			"ip_address": "10.0.1.231",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.231/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.83",
+			"ip_address": "10.0.2.83",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.83/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.209",
+			"ip_address": "10.0.2.209",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.209/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.240",
+			"ip_address": "10.0.3.240",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.240/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.91",
+			"ip_address": "10.0.1.91",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.91/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.26",
+			"ip_address": "10.0.3.26",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.26/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.164",
+			"ip_address": "10.0.1.164",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.164/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.168",
+			"ip_address": "10.0.2.168",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.168/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.8",
+			"ip_address": "10.0.3.8",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.8/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.24",
+			"ip_address": "10.0.3.24",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.24/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.12",
+			"ip_address": "10.0.0.12",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.12/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.164",
+			"ip_address": "10.0.2.164",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.164/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.47",
+			"ip_address": "10.0.3.47",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.47/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.96",
+			"ip_address": "10.0.1.96",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.96/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.11",
+			"ip_address": "10.0.0.11",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.11/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.37",
+			"ip_address": "10.0.0.37",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.37/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.1",
+			"ip_address": "10.0.0.1",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.1/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.180",
+			"ip_address": "10.0.0.180",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.180/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.217",
+			"ip_address": "10.0.0.217",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.217/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.12",
+			"ip_address": "10.0.2.12",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.12/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.106",
+			"ip_address": "10.0.2.106",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.106/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.242",
+			"ip_address": "10.0.2.242",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.242/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.113",
+			"ip_address": "10.0.3.113",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.113/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.239",
+			"ip_address": "10.0.3.239",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.239/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.5",
+			"ip_address": "10.0.0.5",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.5/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.197",
+			"ip_address": "10.0.3.197",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.197/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.208",
+			"ip_address": "10.0.1.208",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.208/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.208",
+			"ip_address": "10.0.3.208",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.208/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.49",
+			"ip_address": "10.0.2.49",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.49/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.42",
+			"ip_address": "10.0.0.42",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.42/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.247",
+			"ip_address": "10.0.1.247",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.247/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.139",
+			"ip_address": "10.0.2.139",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.139/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.229",
+			"ip_address": "10.0.1.229",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.229/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.121",
+			"ip_address": "10.0.2.121",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.121/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.255",
+			"ip_address": "10.0.3.255",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.255/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.221",
+			"ip_address": "10.0.3.221",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.221/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.205",
+			"ip_address": "10.0.2.205",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.205/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.56",
+			"ip_address": "10.0.1.56",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.56/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.102",
+			"ip_address": "10.0.0.102",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.102/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.25",
+			"ip_address": "10.0.2.25",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.25/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.158",
+			"ip_address": "10.0.2.158",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.158/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.155",
+			"ip_address": "10.0.2.155",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.155/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.31",
+			"ip_address": "10.0.0.31",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.31/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.197",
+			"ip_address": "10.0.1.197",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.197/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.61",
+			"ip_address": "10.0.3.61",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.61/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.0",
+			"ip_address": "10.0.1.0",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.0/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.109",
+			"ip_address": "10.0.2.109",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.109/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.75",
+			"ip_address": "10.0.0.75",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.75/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.64",
+			"ip_address": "10.0.1.64",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.64/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.16",
+			"ip_address": "10.0.0.16",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.16/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.65",
+			"ip_address": "10.0.1.65",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.65/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.68",
+			"ip_address": "10.0.1.68",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.68/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.114",
+			"ip_address": "10.0.0.114",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.114/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.133",
+			"ip_address": "10.0.2.133",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.133/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.181",
+			"ip_address": "10.0.2.181",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.181/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.172",
+			"ip_address": "10.0.1.172",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.172/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.210",
+			"ip_address": "10.0.1.210",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.210/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.159",
+			"ip_address": "10.0.1.159",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.159/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.9",
+			"ip_address": "10.0.2.9",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.9/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.200",
+			"ip_address": "10.0.2.200",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.200/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.32",
+			"ip_address": "10.0.3.32",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.32/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.194",
+			"ip_address": "10.0.2.194",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.194/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.25",
+			"ip_address": "10.0.0.25",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.25/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.145",
+			"ip_address": "10.0.1.145",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.145/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.209",
+			"ip_address": "10.0.3.209",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.209/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.122",
+			"ip_address": "10.0.1.122",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.122/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.226",
+			"ip_address": "10.0.0.226",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.226/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.70",
+			"ip_address": "10.0.1.70",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.70/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.136",
+			"ip_address": "10.0.1.136",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.136/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.116",
+			"ip_address": "10.0.2.116",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.116/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.162",
+			"ip_address": "10.0.2.162",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.162/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.71",
+			"ip_address": "10.0.1.71",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.71/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.60",
+			"ip_address": "10.0.0.60",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.60/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.69",
+			"ip_address": "10.0.2.69",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.69/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.72",
+			"ip_address": "10.0.1.72",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.72/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.150",
+			"ip_address": "10.0.1.150",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.150/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.142",
+			"ip_address": "10.0.3.142",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.142/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.193",
+			"ip_address": "10.0.1.193",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.193/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.78",
+			"ip_address": "10.0.0.78",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.78/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.126",
+			"ip_address": "10.0.0.126",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.126/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.198",
+			"ip_address": "10.0.0.198",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.198/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.163",
+			"ip_address": "10.0.1.163",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.163/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.237",
+			"ip_address": "10.0.0.237",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.237/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.69",
+			"ip_address": "10.0.1.69",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.69/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.100",
+			"ip_address": "10.0.3.100",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.100/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.230",
+			"ip_address": "10.0.1.230",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.230/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.167",
+			"ip_address": "10.0.1.167",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.167/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.108",
+			"ip_address": "10.0.3.108",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.108/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.8",
+			"ip_address": "10.0.0.8",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.8/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.97",
+			"ip_address": "10.0.2.97",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.97/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.242",
+			"ip_address": "10.0.3.242",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.242/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.171",
+			"ip_address": "10.0.1.171",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.171/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.149",
+			"ip_address": "10.0.2.149",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.149/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.17",
+			"ip_address": "10.0.0.17",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.17/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.229",
+			"ip_address": "10.0.0.229",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.229/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.98",
+			"ip_address": "10.0.1.98",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.98/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.23",
+			"ip_address": "10.0.3.23",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.23/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.66",
+			"ip_address": "10.0.0.66",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.66/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.133",
+			"ip_address": "10.0.0.133",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.133/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.39",
+			"ip_address": "10.0.0.39",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.39/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.41",
+			"ip_address": "10.0.0.41",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.41/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.216",
+			"ip_address": "10.0.0.216",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.216/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.20",
+			"ip_address": "10.0.0.20",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.20/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.109",
+			"ip_address": "10.0.0.109",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.109/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.237",
+			"ip_address": "10.0.3.237",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.237/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.115",
+			"ip_address": "10.0.0.115",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.115/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.191",
+			"ip_address": "10.0.0.191",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.191/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.176",
+			"ip_address": "10.0.2.176",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.176/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.248",
+			"ip_address": "10.0.3.248",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.248/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.89",
+			"ip_address": "10.0.3.89",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.89/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.55",
+			"ip_address": "10.0.3.55",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.55/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.29",
+			"ip_address": "10.0.3.29",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.29/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.70",
+			"ip_address": "10.0.0.70",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.70/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.140",
+			"ip_address": "10.0.3.140",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.140/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.204",
+			"ip_address": "10.0.0.204",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.204/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.46",
+			"ip_address": "10.0.3.46",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.46/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.141",
+			"ip_address": "10.0.3.141",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.141/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.16",
+			"ip_address": "10.0.1.16",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.16/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.229",
+			"ip_address": "10.0.2.229",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.229/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.53",
+			"ip_address": "10.0.0.53",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.53/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.27",
+			"ip_address": "10.0.2.27",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.27/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.237",
+			"ip_address": "10.0.2.237",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.237/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.188",
+			"ip_address": "10.0.1.188",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.188/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.202",
+			"ip_address": "10.0.1.202",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.202/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.91",
+			"ip_address": "10.0.2.91",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.91/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.243",
+			"ip_address": "10.0.3.243",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.243/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.135",
+			"ip_address": "10.0.1.135",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.135/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.206",
+			"ip_address": "10.0.3.206",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.206/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.43",
+			"ip_address": "10.0.1.43",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.43/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.203",
+			"ip_address": "10.0.2.203",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.203/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.32",
+			"ip_address": "10.0.0.32",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.32/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.145",
+			"ip_address": "10.0.2.145",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.145/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.162",
+			"ip_address": "10.0.1.162",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.162/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.106",
+			"ip_address": "10.0.0.106",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.106/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.75",
+			"ip_address": "10.0.3.75",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.75/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.80",
+			"ip_address": "10.0.1.80",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.80/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.197",
+			"ip_address": "10.0.0.197",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.197/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.204",
+			"ip_address": "10.0.3.204",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.204/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.113",
+			"ip_address": "10.0.0.113",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.113/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.220",
+			"ip_address": "10.0.2.220",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.220/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.165",
+			"ip_address": "10.0.3.165",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.165/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.50",
+			"ip_address": "10.0.3.50",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.50/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.17",
+			"ip_address": "10.0.2.17",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.17/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.30",
+			"ip_address": "10.0.1.30",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.30/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.84",
+			"ip_address": "10.0.1.84",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.84/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.176",
+			"ip_address": "10.0.1.176",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.176/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.60",
+			"ip_address": "10.0.1.60",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.60/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.135",
+			"ip_address": "10.0.2.135",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.135/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.183",
+			"ip_address": "10.0.2.183",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.183/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.33",
+			"ip_address": "10.0.0.33",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.33/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.147",
+			"ip_address": "10.0.2.147",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.147/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.181",
+			"ip_address": "10.0.1.181",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.181/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.198",
+			"ip_address": "10.0.2.198",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.198/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.217",
+			"ip_address": "10.0.3.217",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.217/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.109",
+			"ip_address": "10.0.1.109",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.109/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.4",
+			"ip_address": "10.0.3.4",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.4/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.92",
+			"ip_address": "10.0.3.92",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.92/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.231",
+			"ip_address": "10.0.3.231",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.231/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.127",
+			"ip_address": "10.0.2.127",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.127/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.155",
+			"ip_address": "10.0.3.155",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.155/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.190",
+			"ip_address": "10.0.0.190",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.190/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.247",
+			"ip_address": "10.0.3.247",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.247/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.210",
+			"ip_address": "10.0.3.210",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.210/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.136",
+			"ip_address": "10.0.0.136",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.136/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.178",
+			"ip_address": "10.0.1.178",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.178/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.177",
+			"ip_address": "10.0.0.177",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.177/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.220",
+			"ip_address": "10.0.0.220",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.220/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.102",
+			"ip_address": "10.0.3.102",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.102/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.183",
+			"ip_address": "10.0.1.183",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.183/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.158",
+			"ip_address": "10.0.3.158",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.158/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.178",
+			"ip_address": "10.0.2.178",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.178/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.191",
+			"ip_address": "10.0.3.191",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.191/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.226",
+			"ip_address": "10.0.2.226",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.226/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.60",
+			"ip_address": "10.0.3.60",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.60/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.82",
+			"ip_address": "10.0.2.82",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.82/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.14",
+			"ip_address": "10.0.1.14",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.14/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.110",
+			"ip_address": "10.0.1.110",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.110/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.57",
+			"ip_address": "10.0.3.57",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.57/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.249",
+			"ip_address": "10.0.2.249",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.249/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.138",
+			"ip_address": "10.0.2.138",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.138/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.211",
+			"ip_address": "10.0.3.211",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.211/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.93",
+			"ip_address": "10.0.2.93",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.93/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.58",
+			"ip_address": "10.0.1.58",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.58/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.227",
+			"ip_address": "10.0.2.227",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.227/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.127",
+			"ip_address": "10.0.1.127",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.127/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.153",
+			"ip_address": "10.0.3.153",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.153/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.51",
+			"ip_address": "10.0.0.51",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.51/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.107",
+			"ip_address": "10.0.2.107",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.107/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.134",
+			"ip_address": "10.0.1.134",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.134/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.146",
+			"ip_address": "10.0.1.146",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.146/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.63",
+			"ip_address": "10.0.2.63",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.63/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.69",
+			"ip_address": "10.0.0.69",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.69/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.189",
+			"ip_address": "10.0.2.189",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.189/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.40",
+			"ip_address": "10.0.2.40",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.40/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.99",
+			"ip_address": "10.0.1.99",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.99/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.205",
+			"ip_address": "10.0.1.205",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.205/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.48",
+			"ip_address": "10.0.2.48",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.48/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.241",
+			"ip_address": "10.0.0.241",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.241/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.14",
+			"ip_address": "10.0.3.14",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.14/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.238",
+			"ip_address": "10.0.1.238",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.238/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.19",
+			"ip_address": "10.0.1.19",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.19/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.190",
+			"ip_address": "10.0.1.190",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.190/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.115",
+			"ip_address": "10.0.3.115",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.115/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.38",
+			"ip_address": "10.0.0.38",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.38/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.151",
+			"ip_address": "10.0.0.151",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.151/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.122",
+			"ip_address": "10.0.2.122",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.122/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.123",
+			"ip_address": "10.0.3.123",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.123/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.15",
+			"ip_address": "10.0.3.15",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.15/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.66",
+			"ip_address": "10.0.1.66",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.66/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.250",
+			"ip_address": "10.0.2.250",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.250/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.77",
+			"ip_address": "10.0.3.77",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.77/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.95",
+			"ip_address": "10.0.2.95",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.95/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.191",
+			"ip_address": "10.0.2.191",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.191/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.72",
+			"ip_address": "10.0.0.72",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.72/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.47",
+			"ip_address": "10.0.0.47",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.47/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.112",
+			"ip_address": "10.0.0.112",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.112/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.71",
+			"ip_address": "10.0.3.71",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.71/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.173",
+			"ip_address": "10.0.3.173",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.173/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.118",
+			"ip_address": "10.0.0.118",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.118/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.93",
+			"ip_address": "10.0.1.93",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.93/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.99",
+			"ip_address": "10.0.2.99",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.99/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.120",
+			"ip_address": "10.0.2.120",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.120/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.216",
+			"ip_address": "10.0.3.216",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.216/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.167",
+			"ip_address": "10.0.2.167",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.167/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.144",
+			"ip_address": "10.0.2.144",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.144/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.197",
+			"ip_address": "10.0.2.197",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.197/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.147",
+			"ip_address": "10.0.3.147",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.147/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.170",
+			"ip_address": "10.0.3.170",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.170/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.128",
+			"ip_address": "10.0.3.128",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.128/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.243",
+			"ip_address": "10.0.0.243",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.243/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.234",
+			"ip_address": "10.0.1.234",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.234/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.61",
+			"ip_address": "10.0.2.61",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.61/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.185",
+			"ip_address": "10.0.0.185",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.185/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.1",
+			"ip_address": "10.0.1.1",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.1/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.136",
+			"ip_address": "10.0.3.136",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.136/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.139",
+			"ip_address": "10.0.3.139",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.139/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.51",
+			"ip_address": "10.0.3.51",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.51/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.232",
+			"ip_address": "10.0.2.232",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.232/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.255",
+			"ip_address": "10.0.1.255",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.255/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.182",
+			"ip_address": "10.0.1.182",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.182/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.28",
+			"ip_address": "10.0.1.28",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.28/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.98",
+			"ip_address": "10.0.3.98",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.98/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.18",
+			"ip_address": "10.0.0.18",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.18/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.14",
+			"ip_address": "10.0.2.14",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.14/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.47",
+			"ip_address": "10.0.2.47",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.47/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.63",
+			"ip_address": "10.0.3.63",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.63/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.253",
+			"ip_address": "10.0.3.253",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.253/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.105",
+			"ip_address": "10.0.1.105",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.105/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.40",
+			"ip_address": "10.0.3.40",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.40/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.229",
+			"ip_address": "10.0.3.229",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.229/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.13",
+			"ip_address": "10.0.3.13",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.13/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.84",
+			"ip_address": "10.0.3.84",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.84/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.34",
+			"ip_address": "10.0.0.34",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.34/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.195",
+			"ip_address": "10.0.2.195",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.195/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.172",
+			"ip_address": "10.0.0.172",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.172/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.227",
+			"ip_address": "10.0.1.227",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.227/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.135",
+			"ip_address": "10.0.0.135",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.135/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.23",
+			"ip_address": "10.0.1.23",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.23/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.163",
+			"ip_address": "10.0.2.163",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.163/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.76",
+			"ip_address": "10.0.3.76",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.76/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.192",
+			"ip_address": "10.0.0.192",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.192/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.165",
+			"ip_address": "10.0.1.165",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.165/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.129",
+			"ip_address": "10.0.1.129",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.129/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.28",
+			"ip_address": "10.0.3.28",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.28/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.54",
+			"ip_address": "10.0.0.54",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.54/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.128",
+			"ip_address": "10.0.2.128",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.128/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.86",
+			"ip_address": "10.0.0.86",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.86/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.213",
+			"ip_address": "10.0.2.213",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.213/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.27",
+			"ip_address": "10.0.0.27",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.27/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.160",
+			"ip_address": "10.0.3.160",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.160/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.153",
+			"ip_address": "10.0.0.153",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.153/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.43",
+			"ip_address": "10.0.0.43",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.43/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.170",
+			"ip_address": "10.0.0.170",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.170/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.153",
+			"ip_address": "10.0.1.153",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.153/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.114",
+			"ip_address": "10.0.2.114",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.114/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.104",
+			"ip_address": "10.0.3.104",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.104/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.182",
+			"ip_address": "10.0.3.182",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.182/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.114",
+			"ip_address": "10.0.3.114",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.114/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.169",
+			"ip_address": "10.0.0.169",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.169/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.158",
+			"ip_address": "10.0.0.158",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.158/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.78",
+			"ip_address": "10.0.1.78",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.78/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.90",
+			"ip_address": "10.0.1.90",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.90/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.198",
+			"ip_address": "10.0.3.198",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.198/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.129",
+			"ip_address": "10.0.0.129",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.129/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.124",
+			"ip_address": "10.0.1.124",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.124/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.185",
+			"ip_address": "10.0.2.185",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.185/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.161",
+			"ip_address": "10.0.2.161",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.161/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.177",
+			"ip_address": "10.0.3.177",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.177/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.232",
+			"ip_address": "10.0.3.232",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.232/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.194",
+			"ip_address": "10.0.1.194",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.194/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.13",
+			"ip_address": "10.0.0.13",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.13/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.132",
+			"ip_address": "10.0.2.132",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.132/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.111",
+			"ip_address": "10.0.1.111",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.111/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.2",
+			"ip_address": "10.0.1.2",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.2/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.169",
+			"ip_address": "10.0.2.169",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.169/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.212",
+			"ip_address": "10.0.2.212",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.212/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.91",
+			"ip_address": "10.0.0.91",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.91/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.187",
+			"ip_address": "10.0.2.187",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.187/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.227",
+			"ip_address": "10.0.3.227",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.227/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.150",
+			"ip_address": "10.0.2.150",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.150/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.38",
+			"ip_address": "10.0.3.38",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.38/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.193",
+			"ip_address": "10.0.3.193",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.193/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.251",
+			"ip_address": "10.0.3.251",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.251/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.152",
+			"ip_address": "10.0.3.152",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.152/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.195",
+			"ip_address": "10.0.1.195",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.195/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.94",
+			"ip_address": "10.0.3.94",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.94/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.248",
+			"ip_address": "10.0.1.248",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.248/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.98",
+			"ip_address": "10.0.0.98",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.98/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.150",
+			"ip_address": "10.0.3.150",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.150/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.117",
+			"ip_address": "10.0.0.117",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.117/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.83",
+			"ip_address": "10.0.3.83",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.83/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.246",
+			"ip_address": "10.0.3.246",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.246/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.241",
+			"ip_address": "10.0.2.241",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.241/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.124",
+			"ip_address": "10.0.2.124",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.124/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.204",
+			"ip_address": "10.0.2.204",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.204/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.218",
+			"ip_address": "10.0.0.218",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.218/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.104",
+			"ip_address": "10.0.2.104",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.104/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.184",
+			"ip_address": "10.0.1.184",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.184/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.201",
+			"ip_address": "10.0.2.201",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.201/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.245",
+			"ip_address": "10.0.2.245",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.245/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.53",
+			"ip_address": "10.0.1.53",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.53/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.133",
+			"ip_address": "10.0.3.133",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.133/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.146",
+			"ip_address": "10.0.2.146",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.146/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.139",
+			"ip_address": "10.0.1.139",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.139/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.34",
+			"ip_address": "10.0.2.34",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.34/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.56",
+			"ip_address": "10.0.2.56",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.56/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.158",
+			"ip_address": "10.0.1.158",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.158/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.252",
+			"ip_address": "10.0.3.252",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.252/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.191",
+			"ip_address": "10.0.1.191",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.191/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.45",
+			"ip_address": "10.0.1.45",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.45/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.125",
+			"ip_address": "10.0.3.125",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.125/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.45",
+			"ip_address": "10.0.0.45",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.45/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.148",
+			"ip_address": "10.0.2.148",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.148/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.120",
+			"ip_address": "10.0.3.120",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.120/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.180",
+			"ip_address": "10.0.2.180",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.180/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.223",
+			"ip_address": "10.0.2.223",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.223/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.55",
+			"ip_address": "10.0.0.55",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.55/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.31",
+			"ip_address": "10.0.3.31",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.31/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.29",
+			"ip_address": "10.0.1.29",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.29/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.86",
+			"ip_address": "10.0.3.86",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.86/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.47",
+			"ip_address": "10.0.1.47",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.47/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.122",
+			"ip_address": "10.0.3.122",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.122/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.127",
+			"ip_address": "10.0.3.127",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.127/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.6",
+			"ip_address": "10.0.3.6",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.6/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.208",
+			"ip_address": "10.0.0.208",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.208/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.199",
+			"ip_address": "10.0.3.199",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.199/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.80",
+			"ip_address": "10.0.2.80",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.80/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.51",
+			"ip_address": "10.0.1.51",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.51/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.201",
+			"ip_address": "10.0.0.201",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.201/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.198",
+			"ip_address": "10.0.1.198",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.198/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.145",
+			"ip_address": "10.0.0.145",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.145/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.62",
+			"ip_address": "10.0.2.62",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.62/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.149",
+			"ip_address": "10.0.0.149",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.149/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.225",
+			"ip_address": "10.0.3.225",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.225/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.2",
+			"ip_address": "10.0.3.2",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.2/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.213",
+			"ip_address": "10.0.1.213",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.213/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.108",
+			"ip_address": "10.0.2.108",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.108/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.143",
+			"ip_address": "10.0.3.143",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.143/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.18",
+			"ip_address": "10.0.1.18",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.18/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.116",
+			"ip_address": "10.0.1.116",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.116/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.223",
+			"ip_address": "10.0.3.223",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.223/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.222",
+			"ip_address": "10.0.0.222",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.222/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.15",
+			"ip_address": "10.0.0.15",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.15/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.209",
+			"ip_address": "10.0.1.209",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.209/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.117",
+			"ip_address": "10.0.3.117",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.117/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.84",
+			"ip_address": "10.0.0.84",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.84/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.196",
+			"ip_address": "10.0.2.196",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.196/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.174",
+			"ip_address": "10.0.0.174",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.174/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.130",
+			"ip_address": "10.0.1.130",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.130/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.163",
+			"ip_address": "10.0.0.163",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.163/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.224",
+			"ip_address": "10.0.1.224",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.224/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.42",
+			"ip_address": "10.0.1.42",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.42/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.189",
+			"ip_address": "10.0.1.189",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.189/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.242",
+			"ip_address": "10.0.1.242",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.242/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.77",
+			"ip_address": "10.0.2.77",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.77/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.48",
+			"ip_address": "10.0.1.48",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.48/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.9",
+			"ip_address": "10.0.3.9",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.9/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.111",
+			"ip_address": "10.0.0.111",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.111/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.140",
+			"ip_address": "10.0.1.140",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.140/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.62",
+			"ip_address": "10.0.1.62",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.62/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.48",
+			"ip_address": "10.0.3.48",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.48/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.10",
+			"ip_address": "10.0.1.10",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.10/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.217",
+			"ip_address": "10.0.1.217",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.217/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.103",
+			"ip_address": "10.0.2.103",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.103/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.121",
+			"ip_address": "10.0.3.121",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.121/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.233",
+			"ip_address": "10.0.0.233",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.233/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.154",
+			"ip_address": "10.0.1.154",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.154/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.94",
+			"ip_address": "10.0.0.94",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.94/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.93",
+			"ip_address": "10.0.0.93",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.93/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.227",
+			"ip_address": "10.0.0.227",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.227/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.235",
+			"ip_address": "10.0.2.235",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.235/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.25",
+			"ip_address": "10.0.1.25",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.25/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.5",
+			"ip_address": "10.0.3.5",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.5/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.214",
+			"ip_address": "10.0.0.214",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.214/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.128",
+			"ip_address": "10.0.1.128",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.128/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.137",
+			"ip_address": "10.0.1.137",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.137/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.235",
+			"ip_address": "10.0.0.235",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.235/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.96",
+			"ip_address": "10.0.3.96",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.96/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.219",
+			"ip_address": "10.0.0.219",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.219/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.59",
+			"ip_address": "10.0.2.59",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.59/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.127",
+			"ip_address": "10.0.0.127",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.127/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.119",
+			"ip_address": "10.0.2.119",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.119/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.81",
+			"ip_address": "10.0.3.81",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.81/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.46",
+			"ip_address": "10.0.0.46",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.46/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.67",
+			"ip_address": "10.0.0.67",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.67/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.82",
+			"ip_address": "10.0.1.82",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.82/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.36",
+			"ip_address": "10.0.2.36",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.36/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.237",
+			"ip_address": "10.0.1.237",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.237/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.36",
+			"ip_address": "10.0.3.36",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.36/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.20",
+			"ip_address": "10.0.3.20",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.20/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.32",
+			"ip_address": "10.0.2.32",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.32/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.40",
+			"ip_address": "10.0.1.40",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.40/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.117",
+			"ip_address": "10.0.1.117",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.117/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.86",
+			"ip_address": "10.0.2.86",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.86/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.22",
+			"ip_address": "10.0.2.22",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.22/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.231",
+			"ip_address": "10.0.0.231",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.231/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.169",
+			"ip_address": "10.0.3.169",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.169/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.74",
+			"ip_address": "10.0.0.74",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.74/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.251",
+			"ip_address": "10.0.2.251",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.251/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.27",
+			"ip_address": "10.0.3.27",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.27/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.134",
+			"ip_address": "10.0.3.134",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.134/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.207",
+			"ip_address": "10.0.3.207",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.207/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.151",
+			"ip_address": "10.0.2.151",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.151/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.214",
+			"ip_address": "10.0.3.214",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.214/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.247",
+			"ip_address": "10.0.0.247",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.247/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.46",
+			"ip_address": "10.0.1.46",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.46/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.212",
+			"ip_address": "10.0.1.212",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.212/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.94",
+			"ip_address": "10.0.1.94",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.94/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.129",
+			"ip_address": "10.0.3.129",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.129/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.65",
+			"ip_address": "10.0.0.65",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.65/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.81",
+			"ip_address": "10.0.2.81",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.81/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.225",
+			"ip_address": "10.0.1.225",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.225/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.78",
+			"ip_address": "10.0.2.78",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.78/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.7",
+			"ip_address": "10.0.3.7",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.7/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.71",
+			"ip_address": "10.0.2.71",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.71/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.231",
+			"ip_address": "10.0.2.231",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.231/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.213",
+			"ip_address": "10.0.0.213",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.213/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.100",
+			"ip_address": "10.0.1.100",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.100/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.134",
+			"ip_address": "10.0.2.134",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.134/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.113",
+			"ip_address": "10.0.2.113",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.113/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.92",
+			"ip_address": "10.0.2.92",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.92/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.4",
+			"ip_address": "10.0.1.4",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.4/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.124",
+			"ip_address": "10.0.0.124",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.124/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.193",
+			"ip_address": "10.0.2.193",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.193/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.36",
+			"ip_address": "10.0.0.36",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.36/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.236",
+			"ip_address": "10.0.2.236",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.236/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.222",
+			"ip_address": "10.0.3.222",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.222/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.241",
+			"ip_address": "10.0.3.241",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.241/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.21",
+			"ip_address": "10.0.1.21",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.21/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.138",
+			"ip_address": "10.0.1.138",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.138/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.121",
+			"ip_address": "10.0.0.121",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.121/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.148",
+			"ip_address": "10.0.1.148",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.148/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.230",
+			"ip_address": "10.0.3.230",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.230/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.85",
+			"ip_address": "10.0.0.85",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.85/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.204",
+			"ip_address": "10.0.1.204",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.204/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.24",
+			"ip_address": "10.0.0.24",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.24/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.22",
+			"ip_address": "10.0.1.22",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.22/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.67",
+			"ip_address": "10.0.1.67",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.67/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.40",
+			"ip_address": "10.0.0.40",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.40/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.6",
+			"ip_address": "10.0.0.6",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.6/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.228",
+			"ip_address": "10.0.0.228",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.228/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.179",
+			"ip_address": "10.0.3.179",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.179/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.147",
+			"ip_address": "10.0.0.147",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.147/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.95",
+			"ip_address": "10.0.1.95",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.95/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.176",
+			"ip_address": "10.0.3.176",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.176/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.122",
+			"ip_address": "10.0.0.122",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.122/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.200",
+			"ip_address": "10.0.1.200",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.200/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.7",
+			"ip_address": "10.0.2.7",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.7/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.36",
+			"ip_address": "10.0.1.36",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.36/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.254",
+			"ip_address": "10.0.1.254",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.254/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.166",
+			"ip_address": "10.0.1.166",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.166/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.144",
+			"ip_address": "10.0.1.144",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.144/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.234",
+			"ip_address": "10.0.2.234",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.234/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.236",
+			"ip_address": "10.0.3.236",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.236/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.108",
+			"ip_address": "10.0.0.108",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.108/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.143",
+			"ip_address": "10.0.1.143",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.143/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.155",
+			"ip_address": "10.0.1.155",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.155/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.73",
+			"ip_address": "10.0.3.73",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.73/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.55",
+			"ip_address": "10.0.2.55",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.55/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.101",
+			"ip_address": "10.0.1.101",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.101/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.253",
+			"ip_address": "10.0.2.253",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.253/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.115",
+			"ip_address": "10.0.2.115",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.115/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.75",
+			"ip_address": "10.0.1.75",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.75/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.92",
+			"ip_address": "10.0.0.92",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.92/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.9",
+			"ip_address": "10.0.0.9",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.9/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.64",
+			"ip_address": "10.0.2.64",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.64/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.213",
+			"ip_address": "10.0.3.213",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.213/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.200",
+			"ip_address": "10.0.0.200",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.200/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.235",
+			"ip_address": "10.0.1.235",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.235/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.1",
+			"ip_address": "10.0.3.1",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.1/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.244",
+			"ip_address": "10.0.2.244",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.244/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.151",
+			"ip_address": "10.0.3.151",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.151/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.210",
+			"ip_address": "10.0.0.210",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.210/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.85",
+			"ip_address": "10.0.3.85",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.85/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.99",
+			"ip_address": "10.0.3.99",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.99/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.193",
+			"ip_address": "10.0.0.193",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.193/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.57",
+			"ip_address": "10.0.2.57",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.57/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.10",
+			"ip_address": "10.0.3.10",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.10/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.167",
+			"ip_address": "10.0.0.167",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.167/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.61",
+			"ip_address": "10.0.1.61",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.61/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.125",
+			"ip_address": "10.0.2.125",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.125/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.110",
+			"ip_address": "10.0.3.110",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.110/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.178",
+			"ip_address": "10.0.3.178",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.178/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.96",
+			"ip_address": "10.0.0.96",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.96/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.54",
+			"ip_address": "10.0.1.54",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.54/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.156",
+			"ip_address": "10.0.1.156",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.156/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.66",
+			"ip_address": "10.0.3.66",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.66/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.156",
+			"ip_address": "10.0.3.156",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.156/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.71",
+			"ip_address": "10.0.0.71",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.71/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.10",
+			"ip_address": "10.0.2.10",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.10/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.23",
+			"ip_address": "10.0.0.23",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.23/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.64",
+			"ip_address": "10.0.3.64",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.64/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.35",
+			"ip_address": "10.0.3.35",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.35/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.16",
+			"ip_address": "10.0.3.16",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.16/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.87",
+			"ip_address": "10.0.1.87",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.87/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.250",
+			"ip_address": "10.0.3.250",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.250/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.43",
+			"ip_address": "10.0.2.43",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.43/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.30",
+			"ip_address": "10.0.2.30",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.30/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.76",
+			"ip_address": "10.0.0.76",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.76/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.234",
+			"ip_address": "10.0.3.234",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.234/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.105",
+			"ip_address": "10.0.3.105",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.105/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.90",
+			"ip_address": "10.0.3.90",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.90/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.166",
+			"ip_address": "10.0.2.166",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.166/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.54",
+			"ip_address": "10.0.3.54",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.54/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.163",
+			"ip_address": "10.0.3.163",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.163/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.84",
+			"ip_address": "10.0.2.84",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.84/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.50",
+			"ip_address": "10.0.1.50",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.50/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.126",
+			"ip_address": "10.0.2.126",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.126/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.116",
+			"ip_address": "10.0.0.116",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.116/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.107",
+			"ip_address": "10.0.0.107",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.107/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.184",
+			"ip_address": "10.0.0.184",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.184/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.111",
+			"ip_address": "10.0.2.111",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.111/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.141",
+			"ip_address": "10.0.0.141",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.141/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.218",
+			"ip_address": "10.0.2.218",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.218/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.194",
+			"ip_address": "10.0.3.194",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.194/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.56",
+			"ip_address": "10.0.3.56",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.56/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.173",
+			"ip_address": "10.0.0.173",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.173/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.97",
+			"ip_address": "10.0.1.97",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.97/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.140",
+			"ip_address": "10.0.0.140",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.140/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.236",
+			"ip_address": "10.0.1.236",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.236/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.74",
+			"ip_address": "10.0.1.74",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.74/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.156",
+			"ip_address": "10.0.2.156",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.156/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.52",
+			"ip_address": "10.0.0.52",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.52/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.101",
+			"ip_address": "10.0.3.101",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.101/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.44",
+			"ip_address": "10.0.1.44",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.44/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.104",
+			"ip_address": "10.0.1.104",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.104/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.118",
+			"ip_address": "10.0.3.118",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.118/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.62",
+			"ip_address": "10.0.0.62",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.62/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.57",
+			"ip_address": "10.0.1.57",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.57/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.0",
+			"ip_address": "10.0.3.0",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.0/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.31",
+			"ip_address": "10.0.1.31",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.31/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.214",
+			"ip_address": "10.0.1.214",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.214/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.149",
+			"ip_address": "10.0.3.149",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.149/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.26",
+			"ip_address": "10.0.0.26",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.26/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.110",
+			"ip_address": "10.0.0.110",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.110/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.51",
+			"ip_address": "10.0.2.51",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.51/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.214",
+			"ip_address": "10.0.2.214",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.214/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.49",
+			"ip_address": "10.0.0.49",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.49/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.157",
+			"ip_address": "10.0.3.157",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.157/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.78",
+			"ip_address": "10.0.3.78",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.78/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.88",
+			"ip_address": "10.0.2.88",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.88/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.190",
+			"ip_address": "10.0.2.190",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.190/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.125",
+			"ip_address": "10.0.0.125",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.125/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.68",
+			"ip_address": "10.0.2.68",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.68/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.25",
+			"ip_address": "10.0.3.25",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.25/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.68",
+			"ip_address": "10.0.3.68",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.68/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.85",
+			"ip_address": "10.0.2.85",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.85/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.232",
+			"ip_address": "10.0.0.232",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.232/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.76",
+			"ip_address": "10.0.1.76",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.76/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.238",
+			"ip_address": "10.0.0.238",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.238/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.58",
+			"ip_address": "10.0.2.58",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.58/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.168",
+			"ip_address": "10.0.1.168",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.168/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.76",
+			"ip_address": "10.0.2.76",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.76/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.173",
+			"ip_address": "10.0.2.173",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.173/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.13",
+			"ip_address": "10.0.1.13",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.13/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.240",
+			"ip_address": "10.0.2.240",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.240/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.50",
+			"ip_address": "10.0.2.50",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.50/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.3",
+			"ip_address": "10.0.2.3",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.3/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.130",
+			"ip_address": "10.0.2.130",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.130/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.202",
+			"ip_address": "10.0.2.202",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.202/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.154",
+			"ip_address": "10.0.2.154",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.154/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.205",
+			"ip_address": "10.0.3.205",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.205/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.203",
+			"ip_address": "10.0.1.203",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.203/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.126",
+			"ip_address": "10.0.1.126",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.126/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.217",
+			"ip_address": "10.0.2.217",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.217/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.194",
+			"ip_address": "10.0.0.194",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.194/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.199",
+			"ip_address": "10.0.0.199",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.199/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.202",
+			"ip_address": "10.0.3.202",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.202/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.6",
+			"ip_address": "10.0.2.6",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.6/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.55",
+			"ip_address": "10.0.1.55",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.55/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.82",
+			"ip_address": "10.0.0.82",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.82/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.149",
+			"ip_address": "10.0.1.149",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.149/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.211",
+			"ip_address": "10.0.0.211",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.211/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.225",
+			"ip_address": "10.0.0.225",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.225/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.164",
+			"ip_address": "10.0.3.164",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.164/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.15",
+			"ip_address": "10.0.2.15",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.15/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.81",
+			"ip_address": "10.0.0.81",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.81/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.97",
+			"ip_address": "10.0.0.97",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.97/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.11",
+			"ip_address": "10.0.3.11",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.11/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.87",
+			"ip_address": "10.0.3.87",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.87/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.60",
+			"ip_address": "10.0.2.60",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.60/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.58",
+			"ip_address": "10.0.0.58",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.58/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.54",
+			"ip_address": "10.0.2.54",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.54/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.162",
+			"ip_address": "10.0.3.162",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.162/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.180",
+			"ip_address": "10.0.3.180",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.180/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.179",
+			"ip_address": "10.0.2.179",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.179/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.129",
+			"ip_address": "10.0.2.129",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.129/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.206",
+			"ip_address": "10.0.0.206",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.206/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.105",
+			"ip_address": "10.0.2.105",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.105/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.251",
+			"ip_address": "10.0.1.251",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.251/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.219",
+			"ip_address": "10.0.1.219",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.219/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.126",
+			"ip_address": "10.0.3.126",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.126/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.11",
+			"ip_address": "10.0.2.11",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.11/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.65",
+			"ip_address": "10.0.2.65",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.65/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.125",
+			"ip_address": "10.0.1.125",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.125/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.27",
+			"ip_address": "10.0.1.27",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.27/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.218",
+			"ip_address": "10.0.3.218",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.218/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.203",
+			"ip_address": "10.0.0.203",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.203/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.188",
+			"ip_address": "10.0.3.188",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.188/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.3",
+			"ip_address": "10.0.3.3",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.3/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.19",
+			"ip_address": "10.0.3.19",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.19/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.33",
+			"ip_address": "10.0.1.33",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.33/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.44",
+			"ip_address": "10.0.3.44",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.44/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.135",
+			"ip_address": "10.0.3.135",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.135/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.99",
+			"ip_address": "10.0.0.99",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.99/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.195",
+			"ip_address": "10.0.3.195",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.195/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.112",
+			"ip_address": "10.0.1.112",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.112/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.157",
+			"ip_address": "10.0.2.157",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.157/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.192",
+			"ip_address": "10.0.2.192",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.192/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.32",
+			"ip_address": "10.0.1.32",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.32/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.0.119",
+			"ip_address": "10.0.0.119",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.0.119/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.133",
+			"ip_address": "10.0.1.133",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.133/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.2.70",
+			"ip_address": "10.0.2.70",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.2.70/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.1.216",
+			"ip_address": "10.0.1.216",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.1.216/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:10.0.3.69",
+			"ip_address": "10.0.3.69",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "10.0.0.0/22",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:10.0.3.69/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		}
+	]
+]

--- a/nautobot_ssot_infoblox/tests/fixtures/get_all_ipv4address_networks_medium.json
+++ b/nautobot_ssot_infoblox/tests/fixtures/get_all_ipv4address_networks_medium.json
@@ -1,0 +1,193 @@
+[
+	[
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAwLzA:172.16.0.0",
+			"ip_address": "172.16.0.0",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [],
+			"network": "172.16.0.0/29",
+			"network_view": "default",
+			"objects": [
+				"fixedaddress/ZG5zLmZpeGVkX2FkZHJlc3MkMTAuMjIwLjAuMTAwLjAuLg:172.16.0.0/default"
+			],
+			"status": "USED",
+			"types": [
+				"FA",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAxLzA:172.16.0.1",
+			"ip_address": "172.16.0.1",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "11:11:11:11:11:11",
+			"names": [
+				"testdevice1.test"
+			],
+			"network": "172.16.0.0/29",
+			"network_view": "default",
+			"objects": [
+				"record:host/ZG5zLmhvc3QkLl9kZWZhdWx0LnRlc3QudGVzdGRldmljZTE:testdevice1.test/default"
+			],
+			"status": "USED",
+			"types": [
+				"HOST",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DNS",
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAxLzA:172.16.0.2",
+			"ip_address": "172.16.0.2",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "22:22:22:22:22:22",
+			"names": [
+				"testdevice2.test"
+			],
+			"network": "172.16.0.0/29",
+			"network_view": "default",
+			"objects": [
+				"record:host/ZG5zLmhvc3QkLl9kZWZhdWx0LnRlc3QudGVzdGRldmljZTE:testdevice2.test/default"
+			],
+			"status": "USED",
+			"types": [
+				"HOST",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DNS",
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAxLzA:172.16.0.3",
+			"ip_address": "172.16.0.3",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "33:33:33:33:33:33",
+			"names": [
+				"testdevice3.test"
+			],
+			"network": "172.16.0.0/29",
+			"network_view": "default",
+			"objects": [
+				"record:host/ZG5zLmhvc3QkLl9kZWZhdWx0LnRlc3QudGVzdGRldmljZTE:testdevice3.test/default"
+			],
+			"status": "USED",
+			"types": [
+				"HOST",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DNS",
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAxLzA:172.16.0.4",
+			"ip_address": "172.16.0.4",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "44:44:44:44:44:44",
+			"names": [
+				"testdevice4.test"
+			],
+			"network": "172.16.0.0/29",
+			"network_view": "default",
+			"objects": [
+				"record:host/ZG5zLmhvc3QkLl9kZWZhdWx0LnRlc3QudGVzdGRldmljZTE:testdevice4.test/default"
+			],
+			"status": "USED",
+			"types": [
+				"HOST",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DNS",
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAxLzA:172.16.0.5",
+			"ip_address": "172.16.0.5",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "55:55:55:55:55:55",
+			"names": [
+				"testdevice5.test"
+			],
+			"network": "172.16.0.0/29",
+			"network_view": "default",
+			"objects": [
+				"record:host/ZG5zLmhvc3QkLl9kZWZhdWx0LnRlc3QudGVzdGRldmljZTE:testdevice5.test/default"
+			],
+			"status": "USED",
+			"types": [
+				"HOST",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DNS",
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAxLzA:172.16.0.6",
+			"ip_address": "172.16.0.6",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "66:66:66:66:66:66",
+			"names": [
+				"testdevice6.test"
+			],
+			"network": "172.16.0.0/29",
+			"network_view": "default",
+			"objects": [
+				"record:host/ZG5zLmhvc3QkLl9kZWZhdWx0LnRlc3QudGVzdGRldmljZTE:testdevice6.test/default"
+			],
+			"status": "USED",
+			"types": [
+				"HOST",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DNS",
+				"DHCP"
+			]
+		},
+		{
+			"_ref": "ipv4address/Li5pcHY0X2FkZHJlc3MkMTAuMjIwLjAuMTAxLzA:172.16.0.7",
+			"ip_address": "172.16.0.7",
+			"is_conflict": false,
+			"lease_state": "FREE",
+			"mac_address": "77:77:77:77:77:77",
+			"names": [
+				"testdevice7.test"
+			],
+			"network": "172.16.0.0/29",
+			"network_view": "default",
+			"objects": [
+				"record:host/ZG5zLmhvc3QkLl9kZWZhdWx0LnRlc3QudGVzdGRldmljZTE:testdevice7.test/default"
+			],
+			"status": "USED",
+			"types": [
+				"HOST",
+				"RESERVED_RANGE"
+			],
+			"usage": [
+				"DNS",
+				"DHCP"
+			]
+		}
+	]
+]

--- a/nautobot_ssot_infoblox/tests/fixtures_infoblox.py
+++ b/nautobot_ssot_infoblox/tests/fixtures_infoblox.py
@@ -30,6 +30,21 @@ def get_all_ipv4address_networks():
     return _json_read_fixture("get_all_ipv4address_networks.json")
 
 
+def get_all_ipv4address_networks_medium():
+    """Return all IPv4Address networks from medium size network."""
+    return _json_read_fixture("get_all_ipv4address_networks_medium.json")
+
+
+def get_all_ipv4address_networks_large():
+    """Return all IPv4Address networks from large size network."""
+    return _json_read_fixture("get_all_ipv4address_networks_large.json")
+
+
+def get_all_ipv4address_networks_bulk():
+    """Return all IPv4Address networks from multiple medium networks that result in over 1k addresses."""
+    return _json_read_fixture("get_all_ipv4address_networks_bulk.json")
+
+
 def create_ptr_record():
     """Return a PTR record."""
     return _json_read_fixture("create_ptr_record.json")

--- a/nautobot_ssot_infoblox/tests/test_client.py
+++ b/nautobot_ssot_infoblox/tests/test_client.py
@@ -16,6 +16,9 @@ from nautobot_ssot_infoblox.tests.fixtures_infoblox import (
     get_ptr_record_by_name,
     localhost_client_infoblox,
     get_all_ipv4address_networks,
+    get_all_ipv4address_networks_medium,
+    get_all_ipv4address_networks_large,
+    get_all_ipv4address_networks_bulk,
     create_ptr_record,
     create_a_record,
     create_host_record,
@@ -136,6 +139,53 @@ class TestInfobloxTest(unittest.TestCase):
             response = self.infoblox_client.get_all_ipv4address_networks([(mock_prefix, "default")])
 
             self.assertEqual(response, [])
+
+    def test_get_all_ipv4_address_networks_medium_data_success(self):
+        """Test get_all_ipv4_address_networks success with medium data set."""
+        prefixes = [("172.16.0.0/29", "default"), ("10.220.0.100/31", "default")]
+        mock_uri = "request"
+        response = [get_all_ipv4address_networks_medium()[0] + get_all_ipv4address_networks()[0]]
+        with requests_mock.Mocker() as req:
+            req.post(
+                f"{LOCALHOST}/{mock_uri}",
+                json=response,
+                status_code=201,
+            )
+            resp = self.infoblox_client.get_all_ipv4address_networks(prefixes=prefixes)
+        expected = get_all_ipv4address_networks_medium()[0] + get_all_ipv4address_networks()[0]
+        self.assertEqual(resp, expected)
+
+    def test_get_all_ipv4_address_networks_large_data_success(self):
+        """Test get_all_ipv4_address_networks success with large data set."""
+        prefixes = [("10.0.0.0/22", "default"), ("10.220.0.100/31", "default")]
+
+        mock_response = [
+            {"json": get_all_ipv4address_networks_large(), "status_code": 201},
+            {"json": get_all_ipv4address_networks(), "status_code": 201},
+        ]
+        mock_uri = "request"
+
+        with requests_mock.Mocker() as req:
+            req.post(f"{LOCALHOST}/{mock_uri}", mock_response)
+            resp = self.infoblox_client.get_all_ipv4address_networks(prefixes=prefixes)
+
+        expected = get_all_ipv4address_networks_large()[0] + get_all_ipv4address_networks()[0]
+        self.assertEqual(resp, expected)
+
+    def test_get_all_ipv4_address_networks_bulk_data_success(self):
+        """Test get_all_ipv4_address_networks success with a bulk data set that exceeds 1k results."""
+        prefixes = [("192.168.0.0/23", "default"), ("192.168.2.0/23", "default")]
+        mock_uri = "request"
+        with requests_mock.Mocker() as req:
+            req.post(
+                f"{LOCALHOST}/{mock_uri}",
+                [
+                    {"json": get_all_ipv4address_networks_bulk(), "status_code": 201},
+                    {"json": [], "status_code": 201},
+                ],
+            )
+            resp = self.infoblox_client.get_all_ipv4address_networks(prefixes=prefixes)
+        self.assertEqual(resp, get_all_ipv4address_networks_bulk()[0])
 
     def test_get_host_record_by_name_success(self):
         """Test get_host_by_record success."""

--- a/nautobot_ssot_infoblox/tests/test_client.py
+++ b/nautobot_ssot_infoblox/tests/test_client.py
@@ -11,7 +11,7 @@ from requests.models import HTTPError
 import requests_mock
 
 # from requests_mock.mocker import mock
-from nautobot_ssot_infoblox.utils.client import InvalidUrlScheme
+from nautobot_ssot_infoblox.utils.client import InvalidUrlScheme, get_dns_name
 from nautobot_ssot_infoblox.tests.fixtures_infoblox import (
     get_ptr_record_by_name,
     localhost_client_infoblox,
@@ -76,6 +76,18 @@ class TestInfobloxTest(unittest.TestCase):
         with self.assertRaises(InvalidUrlScheme):
             localhost_client_infoblox("file://mock_file.txt")
         self.assertLogs("Invalid URL scheme 'file' found for Infoblox URL. Please correct to use HTTPS.")
+
+    def test_get_dns_name(self):
+        """Test that get_dns_name method returns what we expect."""
+        tests = {
+            "www.test.com": "www.test.com",
+            "ServerName (Dev)": "ServerName_Dev",
+            "Test Printer": "Test_Printer",
+            "(TEST)": "",
+        }
+        for fqdn, expected in tests.items():
+            results = get_dns_name(possible_fqdn=fqdn)
+            self.assertEqual(results, expected)
 
     def test_request_success_generic(self):
         """Test generic _request with OK status."""

--- a/nautobot_ssot_infoblox/utils/client.py
+++ b/nautobot_ssot_infoblox/utils/client.py
@@ -50,7 +50,7 @@ def get_default_ext_attrs(review_list: list) -> dict:
 
 
 def get_dns_name(possible_fqdn: str) -> str:
-    """Validates passed FQDN and returns if found.
+    """Validate passed FQDN and returns if found.
 
     Args:
         possible_fqdn (str): Potential string to be used for IP Address dns_name.

--- a/nautobot_ssot_infoblox/utils/client.py
+++ b/nautobot_ssot_infoblox/utils/client.py
@@ -287,14 +287,18 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
             else:
                 # if we can't add more hosts, make call to get IP addresses with existing payload
                 if network.num_addresses + num_hosts > 1000:
-                    ipaddrs.append(get_ipaddrs(url_path=url_path, data=json.dumps(payload)))
+                    addrs = get_ipaddrs(url_path=url_path, data=json.dumps(payload))
+                    if addrs:
+                        ipaddrs = ipaddrs + addrs
                     payload = []
                     num_hosts = 0
                 else:
                     # make call with individual network if it's larger than 1000 hosts
                     payload = create_payload(prefix=str(network), view=view)
                     payload["args"]["_max_results"] = network.num_addresses
-                    ipaddrs.append(get_ipaddrs(url_path=url_path, data=json.dumps(payload)))
+                    addrs = get_ipaddrs(url_path=url_path, data=json.dumps(payload))
+                    if addrs:
+                        ipaddrs = ipaddrs + addrs
                     payload = []
                     num_hosts = 0
         return ipaddrs

--- a/nautobot_ssot_infoblox/utils/client.py
+++ b/nautobot_ssot_infoblox/utils/client.py
@@ -287,7 +287,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
             except HTTPError as err:
                 logger.info(err.response.text)
             if response and len(response.json()) > 0:
-                logger.info(response.json()[0])
+                logger.debug(response.json()[0])
                 return response.json()[0]
             return []
 

--- a/nautobot_ssot_infoblox/utils/client.py
+++ b/nautobot_ssot_infoblox/utils/client.py
@@ -258,9 +258,10 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
                 response = self._request(method="POST", path=url_path, data=data)
             except HTTPError as err:
                 logger.info(err.response.text)
-                return []
-            logger.info(response.json()[0])
-            return response.json()[0]
+            if len(response.json()) > 0:
+                logger.info(response.json()[0])
+                return response.json()[0]
+            return []
 
         def create_payload(prefix: str, view: str):
             query = {

--- a/nautobot_ssot_infoblox/utils/client.py
+++ b/nautobot_ssot_infoblox/utils/client.py
@@ -326,7 +326,8 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
         for prefix in prefixes:
             view = prefix[1]
             network = ipaddress.ip_network(prefix[0])
-            # make call with individual network if it's larger than 1000 hosts
+            # Due to default of 1000 max_results from Infoblox we must specify a max result limit or limit response to 1000.
+            # Make individual request if it's larger than 1000 hosts and specify max result limit to be number of hosts in prefix.
             if network.num_addresses > 1000:
                 pf_payload = create_payload(prefix=prefix[0], view=view)
                 pf_payload["args"]["_max_results"] = network.num_addresses

--- a/nautobot_ssot_infoblox/utils/client.py
+++ b/nautobot_ssot_infoblox/utils/client.py
@@ -280,7 +280,16 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
         ]
         """
 
-        def get_ipaddrs(url_path, data):
+        def get_ipaddrs(url_path: str, data: dict) -> list:
+            """Retrieve IP addresses specified in data payload.
+
+            Args:
+                url_path (str): The URL path to the API endpoint for requests.
+                data (dict): The data payload query of IP Addresses.
+
+            Returns:
+                list: List of dicts of IP Addresses for the specified prefixes or an empty list if no response.
+            """
             response = None
             try:
                 response = self._request(method="POST", path=url_path, data=data)
@@ -291,7 +300,16 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
                 return response.json()[0]
             return []
 
-        def create_payload(prefix: str, view: str):
+        def create_payload(prefix: str, view: str) -> dict:
+            """Create the payload structure for querying IP Addresses from subnets.
+
+            Args:
+                prefix (str): The prefix to get IP addresses for.
+                view (str): The Network View of the prefix being queried.
+
+            Returns:
+                dict: Dictionary containing query parameters for IP addresses from a prefix intended to be part of a list sent to request endpoint.
+            """
             query = {
                 "method": "GET",
                 "object": "ipv4address",


### PR DESCRIPTION
This PR is for fixing the issue described in #115. This refactors the get_all_ipv4networks function to do the following:

1. It will group together prefixes for a bulk query until the number of addresses reaches 1000 or less.
2. Once the limit is reached the request will be made.
3. If the prefix is larger than 1000 addresses it will make a request for those addresses individually.

This should help ensure that the 1000 result limit is never actually hit and we get all of the IP addresses as we expect. I've written some unit tests to validate the functionality of the method and I've tested with live data that it is working.

While working on this I also found that we need some validation of the DNS being imported for IP Addresses. I've implemented some rudimentary validation of the content for the dns_name attribute for IP Addresses to hopefully avoid the validation check from Nautobot.