### PR TITLE
Container subnet filter

### DIFF
--- a/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot_infoblox/diffsync/adapters/infoblox.py
@@ -76,10 +76,10 @@ class InfobloxAdapter(DiffSync):
             return new_list
         
         """Load InfobloxNetwork DiffSync model."""
-        if PLUGIN_CFG.get("import_subnets"):
+        if PLUGIN_CFG.get("infoblox_import_subnets"):
             subnets = []
             containers = []
-            for prefix in PLUGIN_CFG["import_subnets"]:
+            for prefix in PLUGIN_CFG["infoblox_import_subnets"]:
                 # Get all child containers and subnets
                 cl = get_tree_from_container(prefix)
                 containers.extend(cl)
@@ -92,7 +92,7 @@ class InfobloxAdapter(DiffSync):
                 else:
                     subnets.extend(self.conn.get_all_subnets(prefix=prefix))
             
-            # Remove duplicates if a child subnet is included import_subnets config
+            # Remove duplicates if a child subnet is included infoblox_import_subnets config
             subnets = remove_duplicates(subnets)
             all_networks = remove_duplicates(containers) + subnets
         else:

--- a/nautobot_ssot_infoblox/utils/client.py
+++ b/nautobot_ssot_infoblox/utils/client.py
@@ -1224,7 +1224,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
         logger.info("Infoblox IP Address updated: %s", response.json())
         return response.json()
 
-    def get_network_containers(self):
+    def get_network_containers(self, prefix: str = None):
         """Get all Network Containers.
 
         Returns:
@@ -1248,6 +1248,10 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
             "_return_fields": "network,comment,network_view,extattrs,rir_organization,rir",
             "_max_results": 100000,
         }
+        
+        if prefix:
+            params.update({"network": prefix})
+
         response = self._request("GET", url_path, params=params)
         response = response.json()
         logger.info(response)
@@ -1255,3 +1259,92 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
         for res in results:
             res.update({"status": "container"})
         return results
+    
+    def get_child_network_containers(self, prefix: str):
+        """Get all Child Network Containers for Container.
+
+        Returns:
+            (list) of record dicts
+
+        Return Response:
+        [
+            {
+                "_ref": "networkcontainer/ZG5zLm5ldHdvcmtfY29udGFpbmVyJDE5Mi4xNjguMi4wLzI0LzA:192.168.2.0/23/default",
+                "comment": "Campus LAN",
+                "extattrs": {},
+                "network": "192.168.2.0/24",
+                "network_view": "default",
+                "rir": "NONE",
+            },
+            {
+                "_ref": "networkcontainer/ZG5zLm5ldHdvcmtfY29udGFpbmVyJDE5Mi4xNjguMi4wLzI0LzA:192.168.2.0/23/default",
+                "comment": "Campus LAN 2",
+                "extattrs": {},
+                "network": "192.168.3.0/24",
+                "network_view": "default",
+                "rir": "NONE",
+            }
+        ]
+        """
+        url_path = "networkcontainer"
+        params = {
+            "_return_as_object": 1,
+            "_return_fields": "network,comment,network_view,extattrs,rir_organization,rir",
+            "_max_results": 100000,
+        }
+        params.update({"network_container": prefix})
+        response = self._request("GET", url_path, params=params)
+        response = response.json()
+        logger.info(response)
+        results = response.get("result", [])
+        for res in results:
+            res.update({"status": "container"})
+        return results
+
+    def get_child_subnets_from_container(self, prefix: str):
+        """Get child subnets from container.
+
+        Args:
+            prefix (str): Network prefix - '10.220.0.0/22'
+
+        Returns:
+            (list) of record dicts
+
+        Return Response:
+        [
+            {
+                "_ref": "network/ZG5zLm5ldHdvcmskMTAuMjIzLjAuMC8yMS8w:10.220.0.0/24/default",
+                "comment": "Campus 1",
+                "extattrs": {},
+                "network": "10.220.0.0/24",
+                "network_view": "default",
+                "rir": "NONE",
+                "vlans": [],
+            },
+            {
+                "_ref": "network/ZG5zLm5ldHdvcmskMTAuMjIzLjAuMC8yMS8w:10.220.1.0/24/default",
+                "comment": "Campus 2",
+                "extattrs": {},
+                "network": "10.220.1.0/24",
+                "network_view": "default",
+                "rir": "NONE",
+                "vlans": [],
+            },
+        ]
+        """
+        url_path = "network"
+        params = {
+            "_return_as_object": 1,
+            "_return_fields": "network,network_view,comment,extattrs,rir_organization,rir,vlans",
+            "_max_results": 10000,
+        }
+
+        params.update({"network_container": prefix})
+        
+        try:
+            response = self._request("GET", url_path, params=params)
+        except HTTPError as err:
+            logger.info(err.response.text)
+            return []
+        logger.info(response.json())
+        return response.json().get("result")


### PR DESCRIPTION
- This PR adds the ability to include containers when using the config `infoblox_import_subnets`. If a subnet is included in the config list it will search the entire tree to gather all the networks and subnets under the network container.

- This also fixes the code to match the config name that is in the readme `import_subnets` -> `infoblox_import_subnets`